### PR TITLE
feat(album): Add album-level duplicate detection

### DIFF
--- a/.claude-state.md
+++ b/.claude-state.md
@@ -351,8 +351,8 @@ duperscooper ~/Music --album-mode --album-match-strategy fingerprint
 # Auto strategy (default): canonical matching
 duperscooper ~/Music --album-mode --album-match-strategy auto
 
-# Output formats
-duperscooper ~/Music --album-mode --output json
+# Output formats (both write to stdout, use redirection to save)
+duperscooper ~/Music --album-mode --output json > albums.json
 duperscooper ~/Music --album-mode --output csv > albums.csv
 ```
 

--- a/.claude-state.md
+++ b/.claude-state.md
@@ -1,166 +1,183 @@
 # Claude Development State - duperscooper
 
 **Last Updated:** 2025-10-01
-**Current Branch:** main
-**Latest Commit:** 1649773 - docs: update CLAUDE.md with multithreading
-documentation
+**Current Branch:** feature/album-mode
+**Latest Commit:** f592888 - feat(album): display match method for each album
 
 ## Project Overview
 
-**duperscooper** is a Python CLI application that finds duplicate audio
-files using fuzzy perceptual matching (Chromaprint fingerprints with
-Hamming distance) across different formats, bitrates, and encodings.
+**duperscooper** is a Python CLI application that finds duplicate audio files using fuzzy perceptual matching (Chromaprint fingerprints with Hamming distance) across different formats, bitrates, and encodings. Now includes album-level duplicate detection.
 
 ## Recent Development Session Summary
 
-### Recently Completed: Multithreading Implementation ✅
+### Currently In Progress: Album Mode Implementation 🚧
+
+**Status:** Phases 1-3 Complete, Testing & Phase 4 Pending
+
+**Branch:** feature/album-mode
+
+### Phase 1: Album Detection & Metadata Extraction (COMPLETED - Commit: 5e54aa9)
+
+**Objective:** Detect albums (directories) and extract comprehensive metadata.
+
+**Completed Work:**
+
+1. **Album Data Structure**
+   - Created `Album` dataclass in `src/duperscooper/album.py`
+   - Fields: path, tracks, track_count, musicbrainz_albumid, album_name, artist_name, total_size, avg_quality_score, fingerprints, has_mixed_mb_ids, quality_info
+
+2. **Album Scanner**
+   - Implemented `AlbumScanner` class for album discovery
+   - Non-recursive directory scan (one album = one directory)
+   - MusicBrainz Album ID extraction via ffprobe
+   - Album/artist tag extraction from audio files
+   - Detection of mixed MusicBrainz IDs within album
+   - Leverages existing `AudioHasher` for fingerprinting and caching
+
+3. **Integration**
+   - Added `--album-mode` CLI flag
+   - Added `--album-match-strategy` option (auto, musicbrainz, fingerprint)
+   - Separate output formatting for album mode
+
+### Phase 2: Album Matching Strategies (COMPLETED - Commit: 9cd8e77)
+
+**Objective:** Implement multiple strategies for matching duplicate albums.
+
+**Completed Work:**
+
+1. **AlbumDuplicateFinder Class**
+   - Three matching strategies: `auto`, `musicbrainz`, `fingerprint`
+   - `_match_by_musicbrainz()`: Group by MB ID + track count
+   - `_match_by_fingerprints()`: Perceptual similarity using Union-Find
+   - `album_similarity()`: Average track-by-track similarity
+
+2. **Auto Strategy Enhancement** (Commits: 0adb5b8, 3e00be4)
+   - **Fixed:** Initial bug where tagged/untagged albums didn't group together
+   - **Refactored:** Fingerprint all albums first, then merge by MB IDs
+   - **Canonical Matching:** Albums with MB IDs or ID3 tags establish canonical version
+   - Untagged albums match against canonical versions and inherit their names
+   - Prioritizes: MB ID > ID3 tags > fingerprint similarity
+
+3. **Similarity Calculation**
+   - Track-by-track fingerprint comparison
+   - Average similarity percentage for album grouping
+   - Hamming distance between track fingerprints
+   - Default threshold: 98% (configurable)
+
+### Phase 3: Matched Album/Artist Identification (COMPLETED - Commits: f4fd46f, ac2b4b7, f592888)
+
+**Objective:** Display matched album/artist names and confidence scores.
+
+**Completed Work:**
+
+1. **Matched Album Info** (Commit: f4fd46f)
+   - `get_matched_album_info()`: Determine canonical album/artist for group
+   - Prioritizes albums with MB IDs or complete metadata
+   - Falls back to most common names if no canonical album
+
+2. **Confidence Scoring**
+   - 100%: All albums have matching MusicBrainz Album ID
+   - 90-95%: Album/artist metadata matches + high fingerprint similarity
+   - 80-90%: Fingerprint similarity only (no metadata match)
+   - Calculation factors:
+     - Base: 80%
+     - +5% if album name matches
+     - +5% if artist name matches
+     - +0-10% based on avg fingerprint similarity (98-100% range)
+
+3. **Album Cache in SQLite** (Commit: ac2b4b7)
+   - Added `album_cache` and `album_tracks` tables
+   - Directory mtime-based invalidation
+   - Stores: path, metadata, quality info, track list
+   - Thread-safe with WAL mode (ready for Phase 5)
+   - Schema implemented, integration pending
+
+4. **Match Method Display** (Commit: f592888)
+   - Added `match_method` field to `Album` dataclass
+   - Shows how album was matched in all output formats:
+     - "MusicBrainz Album ID"
+     - "ID3 Album/Artist Tags"
+     - "Acoustic Fingerprint"
+   - Applied to text, JSON, and CSV output
+
+5. **Output Enhancements**
+   - Text: Shows matched album/artist, best quality marker, confidence percentage with color coding
+   - JSON: Includes `matched_album`, `matched_artist`, `confidence`, `match_method` for each album
+   - CSV: Columns for matched info, confidence, match method
+
+### Test Infrastructure (COMPLETED - Current Session)
+
+**Test Scenarios Created:**
+
+1. **Baseline (16 albums)**
+   - AlbumA (9 tracks): 8 versions (FLAC/MP3, with/without MB IDs, various bitrates)
+   - AlbumB (10/11 tracks): 8 versions (FLAC/MP3, with/without MB IDs, various bitrates)
+
+2. **Test Scenario 1: Mixed MusicBrainz IDs**
+   - AlbumA-FLAC-MIXED-MB-IDs (tracks 1-2 correct MB ID, tracks 3-9 fake MB ID)
+   - Expected: Match by ID3 tags, show warning about mixed MB IDs
+
+3. **Test Scenario 2: ID3 Tags Only**
+   - AlbumA-MP3-ID3-ONLY-320 (MB IDs removed via ffmpeg)
+   - AlbumB-MP3-ID3-ONLY-320 (MB IDs removed via ffmpeg)
+   - Expected: Match by ID3 tags, group with canonical albums
+
+4. **Test Scenario 3: Partial Albums**
+   - AlbumA-FLAC-PARTIAL-missing-2-tracks (7 tracks instead of 9)
+   - AlbumB-MP3-PARTIAL-missing-3-tracks (7 tracks instead of 10/11)
+   - Expected: No duplicate groups (only 1 album each)
+
+5. **Documentation**
+   - Created `test-albums/TEST-SCENARIOS.md` with detailed descriptions
+
+**Test Results (Verified ✅):**
+
+- AlbumA group: 10 albums matched correctly (8 baseline + 1 ID3-only + 1 mixed-MB)
+- AlbumB group: 9 albums matched correctly (8 baseline + 1 ID3-only)
+- Partial albums: Correctly excluded (need 2+ albums for duplicate group)
+- Match methods displayed correctly with appropriate confidence scores
+- Mixed MB IDs handled properly with warning
+
+### Previously Completed: Multithreading Implementation ✅
 
 **Status:** All Phases Complete (Phase 1, 2, 3) - Merged to main
 
 **Branch:** main (merged from feature/multithreading)
 
-### Phase 1: SQLite Cache Backend (COMPLETED - Commit: 86d7842)
+**Key Features:**
 
-**Objective:** Implement thread-safe cache storage to enable concurrent
-fingerprinting operations.
+1. **SQLite Cache Backend** (Commit: 86d7842)
+   - Thread-local database connections
+   - WAL mode for concurrent access
+   - Auto-migration from JSON cache
+   - 16 comprehensive unit tests
 
-**Completed Work:**
+2. **Parallel Fingerprinting** (Commit: 1b70aa4)
+   - ThreadPoolExecutor with configurable workers (default: 8)
+   - Real-time ETA estimation
+   - 2.7x speedup on test dataset
+   - Thread-safe progress tracking
 
-1. **Cache Backend Architecture**
-   - Created `src/duperscooper/cache.py` with Protocol-based interface
-   - Implemented `SQLiteCacheBackend` with thread-local connections
-   - Maintained `JSONCacheBackend` for backward compatibility
-   - Added automatic JSON → SQLite migration with backup
+3. **Performance Benchmarks** (Commit: c0fe445)
+   - 8 workers: 63% faster than sequential
+   - ~10 files/second on production dataset
+   - Diminishing returns beyond 8 workers
 
-2. **Thread Safety Features**
-   - Thread-local database connections (one per thread)
-   - WAL (Write-Ahead Logging) mode for concurrent reads/writes
-   - ACID transactions prevent cache corruption
-   - Thread-safe statistics tracking with locks
-
-3. **Integration Changes**
-   - Modified `AudioHasher` to use `CacheBackend` interface
-   - Updated `DuplicateFinder` to pass cache backend parameter
-   - Changed cache stats reporting to use `get_cache_stats()` method
-   - Removed manual `save_cache()` calls (auto-saved by backends)
-
-4. **Testing & Validation**
-   - Added 16 comprehensive unit tests in `tests/test_cache.py`
-   - All 22 tests passing (6 existing + 16 new)
-   - All quality checks passed (Black, Ruff, MyPy)
-   - Production tested with test-audio directory (15 cache hits)
-
-**Database Schema:**
-
-```text
-CREATE TABLE fingerprint_cache (
-    file_hash TEXT PRIMARY KEY,      -- SHA256 of file content
-    fingerprint TEXT NOT NULL,        -- Comma-separated raw fingerprint
-    created_at INTEGER NOT NULL,      -- Unix timestamp
-    last_accessed INTEGER NOT NULL    -- For LRU cleanup
-);
-CREATE INDEX idx_last_accessed ON fingerprint_cache(last_accessed);
-```
-
-**Migration Results:**
-
-- Old cache: `~/.config/duperscooper/hashes.json` → `hashes.json.bak`
-- New cache: `~/.config/duperscooper/hashes.db` (SQLite, 168KB)
-- 15 entries migrated successfully
-
-### Phase 2: ThreadPoolExecutor (COMPLETED - Commit: 1b70aa4)
-
-**Objective:** Parallelize audio fingerprinting operations using thread pool.
-
-**Completed Work:**
-
-1. **Parallel Fingerprinting**
-   - Implemented `_fingerprint_parallel()` using ThreadPoolExecutor
-   - Maintained `_fingerprint_sequential()` for single-threaded mode
-   - Added `max_workers` parameter (default: 8 threads)
-   - Thread-safe result collection with locks
-
-2. **Progress & Time Estimation**
-   - Real-time progress updates (every 10 files or 1 second)
-   - Elapsed time tracking with `_format_time()` helper
-   - ETA calculation based on avg time per file
-   - Human-readable time format (e.g., "2m 30s", "1h 5m")
-
-3. **CLI Options**
-   - Added `--workers` / `-w` flag (default: 8, use 1 for sequential)
-   - Added `--cache-backend` flag (sqlite or json, default: sqlite)
-   - Updated help text with threading information
-
-4. **Testing & Validation**
-   - All 22 tests passing
-   - Tested with 1, 4, and 8 workers successfully
-   - Verified thread-safe cache access with SQLite backend
-   - ETA and elapsed time display working correctly
-
-**Performance Characteristics:**
-
-- I/O-bound workload (subprocess calls to fpcalc)
-- 8 workers optimal for modern multi-core systems
-- Thread-safe SQLite WAL cache handles concurrent access
-- Minimal threading overhead compared to subprocess execution time
-
-**Benchmark Results (15 files, cold cache):**
-
-| Workers | Time    | Speedup | vs Baseline |
-|---------|---------|---------|-------------|
-| 1       | 2.253s  | 1.00x   | baseline    |
-| 2       | 1.474s  | 1.53x   | 35% faster  |
-| 4       | 1.039s  | 2.17x   | 54% faster  |
-| **8**   | **0.835s** | **2.70x** | **63% faster** |
-| 16      | 0.872s  | 2.58x   | 61% faster  |
-
-**Key findings:**
-
-- 8 workers provides optimal performance for test dataset
-- Beyond 8 workers shows diminishing returns (threading overhead)
-- 2.7x speedup on fingerprinting phase with default configuration
-- Larger datasets (50k+ files) benefit even more from parallelization
-- Processing rate: ~10 files/second with 8 workers on production dataset
-
-### Phase 3: Documentation & Finalization (COMPLETED - Commit: 1649773)
-
-**Objective:** Document new features and finalize implementation.
-
-**Completed Work:**
-
-- Updated CLAUDE.md with comprehensive threading documentation
-- Documented new CLI options (--workers, --cache-backend)
-- Updated module structure and key components sections
-- Added multithreading & parallelization section with architecture details
-- Documented worker thread tuning guidelines
-- Added performance optimization tips
-- Merged feature branch to main
-- Ran performance benchmarks on test dataset and production dataset
-
-### Previously Completed Features
+### Previously Completed: Quality Detection & Display
 
 1. **Quality Detection System** (Commit: 942d2ea)
-   - Added ffprobe-based audio metadata extraction
-   - Implemented quality scoring (lossless > lossy)
-   - Enhanced all output formats (text, JSON, CSV) with quality info
-   - Shows [Best] marker and similarity percentages
-   - Updated interactive delete mode with quality information
+   - ffprobe-based metadata extraction
+   - Quality scoring (lossless > lossy)
+   - Enhanced all output formats
 
-2. **Color Output Enhancement** (Commit: c6ac43b)
-   - Added colorama dependency for cross-platform color support
-   - Color-coded progress indicators (cyan with green "done")
-   - Highlighted [Best] files in bright green
-   - Similarity color coding:
-     - Green: ≥99% (excellent match)
-     - Yellow: 95-99% (good match)
-     - Orange/red: <95% (lower quality)
-   - Dimmed file sizes, bolded headers
-   - Applied to all text output (not JSON/CSV)
+2. **Color Output** (Commit: c6ac43b)
+   - Colorama integration
+   - Color-coded similarity percentages
+   - Highlighted [Best] markers
 
 3. **Display Improvements** (Commit: 807c185)
-   - Sort duplicates by similarity descending (best matches first)
-   - Fixed tree drawing: use └─ for last item instead of ├─
-   - Applied to both regular output and interactive delete mode
+   - Sorting by similarity descending
+   - Proper tree drawing (└─ for last item)
 
 ## Current Project State
 
@@ -187,19 +204,37 @@ src/duperscooper/
 ├── __main__.py       # CLI interface, output formatting, colorama integration
 ├── cache.py          # CacheBackend interface, SQLite/JSON implementations
 ├── hasher.py         # AudioHasher: perceptual & exact hashing, metadata
-└── finder.py         # DuplicateFinder: search logic
-                      # DuplicateManager: file operations, quality detection
+├── finder.py         # DuplicateFinder: search logic, parallelization
+│                     # DuplicateManager: file operations
+└── album.py          # Album: dataclass for album metadata
+                      # AlbumScanner: album discovery and metadata extraction
+                      # AlbumDuplicateFinder: album duplicate detection
 ```
 
 ### Key Algorithms
 
-#### Perceptual Matching (Default)
+#### Album Matching (Album Mode)
 
-- Uses raw Chromaprint fingerprints (list of 948 32-bit integers)
+- **Canonical Matching:**
+  1. Identify canonical albums (MB ID > ID3 tags)
+  2. Fingerprint match canonical albums together
+  3. Match untagged albums against canonical groups
+  4. Untagged albums inherit canonical names
+
+- **Match Confidence:**
+  - MusicBrainz ID: 100%
+  - ID3 Album/Artist Tags: 90-95%
+  - Acoustic Fingerprint: 80-90%
+
+- **Album Similarity:** Average track-by-track fingerprint similarity
+
+#### Perceptual Matching (Track Mode)
+
+- Raw Chromaprint fingerprints (948 32-bit integers)
 - Hamming distance for bit-level comparison
 - Default similarity threshold: 98.0%
-- O(n²) with Union-Find grouping (suitable for ~10k files)
-- Detects duplicates across all bitrates and formats
+- O(n²) with Union-Find grouping
+- Detects duplicates across all bitrates/formats
 
 #### Quality Scoring
 
@@ -210,33 +245,43 @@ src/duperscooper/
 
 - **Default Backend:** SQLite (thread-safe, WAL mode)
 - **Location:** `~/.config/duperscooper/hashes.db`
-- **Legacy Backend:** JSON (available with `--cache-backend json`)
-- **Storage:** SHA256 file hash → raw fingerprint (comma-separated integers)
-- **Auto-migration:** JSON cache automatically migrated to SQLite on first run
-- Automatically invalidates when files change
+- **Track Cache:** SHA256 file hash → raw fingerprint
+- **Album Cache:** Directory path → album metadata (schema ready, integration pending)
+- **Auto-migration:** JSON cache automatically migrated to SQLite
 
 ### Test Environment
+
+#### Track Mode Tests
 
 - **Test Files:** `test-audio/` directory
   - test.flac (44.1kHz 16bit, 30.9 MB)
   - 14 MP3 variants (CBR: 64-320kbps, VBR: V2-V9)
   - All successfully detected as duplicates
 
+#### Album Mode Tests
+
+- **Test Folders:** `test-albums/` directory
+  - 21 album folders total
+  - 16 baseline albums (AlbumA × 8, AlbumB × 8)
+  - 5 test scenario folders (mixed MB IDs, ID3-only, partial albums)
+  - All scenarios verified working correctly
+
 ## Development Workflow
 
 ### Quality Checks (Must Pass Before Commit)
 
 ```bash
-.venv/bin/black src/           # Format code
-.venv/bin/ruff check src/      # Lint
-.venv/bin/mypy src/            # Type check
-.venv/bin/pytest tests/ -v     # Run tests
+.venv/bin/black src/ tests/       # Format code
+.venv/bin/ruff check src/ tests/  # Lint
+.venv/bin/mypy src/               # Type check
+.venv/bin/pytest tests/ -v        # Run tests
 ```
 
 ### Git Workflow
 
 - Remote: `origin` = git@github-ohtostado:ohtostado/duperscooper.git
 - Main branch: `main`
+- Feature branch: `feature/album-mode` (current)
 - Commit style: Conventional commits (feat:, fix:, docs:, etc.)
 - Always reference issues: "Fixes #123" or "Implements #456"
 
@@ -259,7 +304,7 @@ duperscooper /path/to/music
 
 ## Current Feature Set
 
-### CLI Options
+### Track Mode (Default)
 
 ```bash
 # Basic usage
@@ -283,34 +328,33 @@ duperscooper --clear-cache
 duperscooper ~/Music --no-cache
 duperscooper ~/Music --update-cache
 
-# Other options
-duperscooper ~/Music --min-size 0           # Include small files
-duperscooper ~/Music --no-progress          # Disable progress output
+# Multithreading
+duperscooper ~/Music --workers 16
+duperscooper ~/Music --workers 1  # Sequential
+
+# Cache backend selection
+duperscooper ~/Music --cache-backend json  # Legacy
 ```
 
-### Output Formats
+### Album Mode (New)
 
-#### Text (Default)
+```bash
+# Find duplicate albums
+duperscooper ~/Music --album-mode
 
-```text
-Found 1 group(s) of duplicate files:
+# MusicBrainz-only matching
+duperscooper ~/Music --album-mode --album-match-strategy musicbrainz
 
-Group 1 (Hash: group_14...)
-  [Best] /path/test.flac (30.9 MB) - FLAC 44.1kHz 16bit
-    ├─ /path/test-c320.mp3 (13.4 MB) - MP3 CBR 320kbps [99.9% match]
-    ├─ /path/test-c192.mp3 (8.0 MB) - MP3 CBR 192kbps [99.8% match]
-    └─ /path/test-c064.mp3 (2.7 MB) - MP3 CBR 64kbps [98.9% match]
+# Fingerprint-only matching
+duperscooper ~/Music --album-mode --album-match-strategy fingerprint
+
+# Auto strategy (default): canonical matching
+duperscooper ~/Music --album-mode --album-match-strategy auto
+
+# Output formats
+duperscooper ~/Music --album-mode --output json
+duperscooper ~/Music --album-mode --output csv > albums.csv
 ```
-
-#### JSON
-
-Includes: `audio_info`, `quality_score`, `similarity_to_best`, `is_best`
-fields
-
-#### CSV
-
-Columns: `group_id,hash,file_path,file_size,file_size_bytes,audio_info,
-quality_score,similarity_to_best,is_best`
 
 ## Known Working State
 
@@ -322,40 +366,83 @@ quality_score,similarity_to_best,is_best`
 
 ### Verified Features ✅
 
+**Track Mode:**
 - Perceptual matching across bitrates (64kbps - FLAC)
 - Exact matching fallback
-- SQLite cache with thread-local connections (Phase 1)
-- JSON → SQLite cache migration
-- Parallel fingerprinting with ThreadPoolExecutor (Phase 2)
-- Elapsed time and ETA estimation (Phase 2)
-- Configurable worker threads (1-N, default 8)
-- Cache persistence and invalidation
+- SQLite cache with thread-local connections
+- Parallel fingerprinting (8 workers, 2.7x speedup)
 - Quality detection and scoring
-- Color output (tested on Linux terminal)
-- Sorting by similarity
-- Interactive deletion
+- Color output
 - All output formats
 
-## Next Steps / Future Enhancements
+**Album Mode:**
+- Album discovery and metadata extraction
+- MusicBrainz ID matching
+- ID3 tag matching
+- Acoustic fingerprint matching
+- Canonical matching (MB ID → ID3 → fingerprint)
+- Mixed MB ID detection and warnings
+- Match method display
+- Confidence scoring
+- All output formats (text, JSON, CSV)
 
-### Immediate Next Steps (Active Development)
+## Next Steps / Future Phases
 
-**Phase 3: Documentation** - Update CLAUDE.md with threading docs and
-merge to main (branch: feature/multithreading)
+### Phase 4: Album Cache Integration (Next - In Progress)
 
-### Potential Features (from CLAUDE.md)
+**Objective:** Use SQLite album cache to speed up repeated scans.
+
+**Tasks:**
+- Integrate `get_album()` / `set_album()` into `AlbumScanner`
+- Directory mtime-based cache invalidation (already in schema)
+- Test cache hits/misses with album mode
+- Measure performance improvement
+
+### Phase 5: Interactive Album Deletion (Pending)
+
+**Objective:** Allow users to interactively delete duplicate albums.
+
+**Tasks:**
+- Implement `AlbumManager` class similar to `DuplicateManager`
+- Add `--delete-duplicates` support for album mode
+- Show album quality, track count, and metadata for decision making
+- Allow preview of album contents before deletion
+- Confirm deletion of directories (not just files)
+
+### Phase 6: Partial Album Detection (Future)
+
+**Objective:** Detect albums with missing tracks as potential duplicates.
+
+**Tasks:**
+- Allow albums with different track counts to match
+- Require minimum overlap (e.g., 70% of tracks match)
+- Show which tracks are present/missing in each version
+- Handle edge cases (bonus tracks, deluxe editions)
+
+### Phase 7: Fuzzy Tag Matching (Future - from CLAUDE.md)
+
+**Objective:** Match albums with misspelled metadata.
+
+**Tasks:**
+- Implement Levenshtein distance or similar algorithm
+- Match album/artist names against canonical versions within threshold
+- Example: "The Beatles" vs "Beatles" or "Led Zeppelin" vs "Led Zepplin"
+- Configurable fuzzy matching sensitivity
+- Useful for poorly tagged or user-edited metadata
+
+### Other Potential Features
 
 - Preview audio before deletion
 - Dry-run mode for `--delete-duplicates`
 - GUI interface
-- More exotic audio format support (AIFF, APE, etc.)
-- Optional fuzzy duration matching (±1 second tolerance)
+- More exotic audio formats (AIFF, APE, etc.)
 
 ### Code Improvements
 
-- More comprehensive integration tests
-- Benchmark Chromaprint performance on large libraries
+- More comprehensive integration tests for album mode
+- Benchmark album mode on large libraries
 - Performance optimization for libraries >10k files
+- Test coverage for album-specific features
 
 ## Important Development Notes
 
@@ -418,23 +505,30 @@ brew install ffmpeg
 
 ### What Was Discussed
 
-1. User requested quality detection feature to identify best quality file
-   in duplicate groups
-2. Requested enhanced output showing quality info, encoding details,
-   similarity percentages
-3. Requested color output for better UX (dark terminal background
-   consideration)
-4. Requested sorting by similarity (best matches first) and proper tree
-   characters (└─ for last item)
+**Previous Sessions:**
+1. Quality detection feature for identifying best quality files
+2. Enhanced output with quality info, encoding details, similarity percentages
+3. Color output for better UX (dark terminal background)
+4. Sorting by similarity and proper tree characters
+5. Multithreading implementation (SQLite cache, parallel fingerprinting)
+
+**Current Session (Album Mode):**
+1. Implemented album-level duplicate detection (Phases 1-3)
+2. Fixed critical matching bug (tagged/untagged albums not grouping)
+3. Implemented canonical matching approach (MB ID → ID3 → fingerprint)
+4. Added match method display and confidence scoring
+5. Created comprehensive test scenarios in test-albums/
+6. Verified all test scenarios working correctly
+7. Added fuzzy tag matching to future enhancements
 
 ### User Preferences
 
 - Uses dark terminal background
 - Values accessibility and readability
 - Prefers industry-standard libraries over custom implementations
-  (e.g., colorama)
 - Likes tasteful, not excessive, color usage
 - Focuses on practical UX improvements
+- Wants transparency in matching methodology
 
 ### Development Philosophy
 
@@ -462,66 +556,73 @@ brew install ffmpeg
    pip install -e .
    ```
 
-3. **Verify setup:**
+3. **Switch to album mode branch:**
 
    ```bash
-   .venv/bin/duperscooper test-audio/
+   git checkout feature/album-mode
    ```
 
-4. **Check all quality tools work:**
+4. **Verify setup:**
 
    ```bash
-   .venv/bin/black src/
-   .venv/bin/ruff check src/
+   # Test track mode
+   .venv/bin/duperscooper test-audio/
+
+   # Test album mode
+   .venv/bin/duperscooper --album-mode test-albums/
+   ```
+
+5. **Check all quality tools work:**
+
+   ```bash
+   .venv/bin/black src/ tests/
+   .venv/bin/ruff check src/ tests/
    .venv/bin/mypy src/
    .venv/bin/pytest tests/ -v
    ```
 
-5. **Review documentation:**
+6. **Review documentation:**
    - Read `CLAUDE.md` (project-specific instructions)
    - Read `~/.claude/CLAUDE.md` (global development guidelines)
    - Review recent commits: `git log --oneline -10`
+   - Review test scenarios: `cat test-albums/TEST-SCENARIOS.md`
 
 ## Files Modified in Recent Sessions
 
-### Session 1: Quality Detection
+### Session 1-3: Quality, Color, Display (Merged to main)
 
-- `src/duperscooper/hasher.py` - Added metadata extraction,
-  quality scoring
-- `src/duperscooper/finder.py` - Modified grouping to preserve
-  fingerprints, added quality detection
-- `src/duperscooper/__main__.py` - Updated all output formats
-- `CLAUDE.md` - Documented quality detection system
-- `pyproject.toml` - Dependencies remain same
-
-### Session 2: Color Output
-
-- `pyproject.toml` - Added colorama>=0.4.6
+- `src/duperscooper/hasher.py` - Metadata extraction, quality scoring
+- `src/duperscooper/finder.py` - Quality detection, color output, sorting
+- `src/duperscooper/__main__.py` - All output formats enhanced
+- `pyproject.toml` - Added colorama dependency
 - `requirements.txt` - Added colorama==0.4.6
-- `src/duperscooper/__main__.py` - Integrated colorama for text output
-- `src/duperscooper/finder.py` - Added colors to progress indicators
-  and interactive delete
 
-### Session 3: Display Improvements
+### Session 4: Multithreading (Merged to main)
 
-- `src/duperscooper/__main__.py` - Sort by similarity, fix tree characters
-- `src/duperscooper/finder.py` - Apply same improvements to interactive delete
+- `src/duperscooper/cache.py` - NEW: Cache backend interface
+- `src/duperscooper/hasher.py` - Refactored for CacheBackend
+- `src/duperscooper/finder.py` - ThreadPoolExecutor, ETA
+- `src/duperscooper/__main__.py` - Added --workers, --cache-backend
+- `tests/test_cache.py` - NEW: 16 unit tests
 
-### Session 4: Multithreading Implementation (Current)
+### Session 5: Album Mode (Current - feature/album-mode branch)
 
-#### Phase 1: SQLite Cache Backend
+**Phase 1:**
+- `src/duperscooper/album.py` - NEW: Album dataclass, AlbumScanner, AlbumDuplicateFinder
+- `src/duperscooper/__main__.py` - Added --album-mode, --album-match-strategy
 
-- `src/duperscooper/cache.py` - NEW: Cache backend interface and
-  implementations
-- `src/duperscooper/hasher.py` - Refactored to use CacheBackend interface
-- `src/duperscooper/finder.py` - Pass cache_backend parameter
-- `tests/test_cache.py` - NEW: 16 unit tests for cache backends
+**Phase 2:**
+- `src/duperscooper/album.py` - Matching strategies, similarity calculation
 
-#### Phase 2: Parallel Fingerprinting
+**Phase 3:**
+- `src/duperscooper/album.py` - Canonical matching, confidence scoring, match_method field
+- `src/duperscooper/cache.py` - Album cache schema (get_album, set_album methods)
+- `src/duperscooper/__main__.py` - Enhanced album output formats
+- `CLAUDE.md` - Added album mode documentation and fuzzy matching future phase
 
-- `src/duperscooper/finder.py` - Added ThreadPoolExecutor, ETA calculation
-- `src/duperscooper/__main__.py` - Added --workers and --cache-backend
-  options
+**Test Infrastructure:**
+- `test-albums/` - 21 test folders created
+- `test-albums/TEST-SCENARIOS.md` - NEW: Test documentation
 
 ## Contact & Resources
 
@@ -532,7 +633,4 @@ brew install ffmpeg
 
 ---
 
-**Note for Claude:** This state file provides complete context to resume
-development. Read this file first, then review `CLAUDE.md` for project
-conventions, then check recent git history. The codebase is in a stable,
-fully tested state with all quality checks passing.
+**Note for Claude:** This state file provides complete context to resume development. Read this file first, then review `CLAUDE.md` for project conventions, then check recent git history. The album mode feature is currently on `feature/album-mode` branch with Phases 1-3 complete and all test scenarios verified.

--- a/.claude-state.md
+++ b/.claude-state.md
@@ -430,6 +430,34 @@ duperscooper ~/Music --album-mode --output csv > albums.csv
 - Configurable fuzzy matching sensitivity
 - Useful for poorly tagged or user-edited metadata
 
+### Phase 8: Strict Fingerprint Mode (Future)
+
+**Objective:** Ultra-conservative duplicate detection that ignores metadata entirely.
+
+**Use Case:** Find true acoustic duplicates when metadata is unreliable or inconsistent.
+
+**Tasks:**
+
+- Add `--strict` or `--fingerprint-strict` flag for both track and album modes
+- Ignore all metadata (MusicBrainz IDs, ID3 tags) completely
+- Use only acoustic fingerprint matching with high threshold (e.g., 99.5% default)
+- Configurable strict threshold: `--strict-threshold 99.5`
+- Useful for:
+  - Libraries with poor/inconsistent tagging
+  - Finding actual duplicate audio regardless of metadata
+  - Avoiding false positives from metadata matches with different audio
+  - Quality control: verify MB ID matches are actually the same recording
+
+**Example Usage:**
+
+```bash
+# Track mode: Find acoustically identical files, ignore metadata
+duperscooper ~/Music --strict --strict-threshold 99.5
+
+# Album mode: Match only by fingerprints with 99.5% threshold
+duperscooper ~/Music --album-mode --strict --strict-threshold 99.5
+```
+
 ### Other Potential Features
 
 - Preview audio before deletion

--- a/.gitignore
+++ b/.gitignore
@@ -208,3 +208,4 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+test-albums/

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,0 +1,1 @@
+.claude-state.md

--- a/ALBUM-TEST-SCENARIOS.md
+++ b/ALBUM-TEST-SCENARIOS.md
@@ -1,0 +1,113 @@
+# Test Album Scenarios
+
+This directory contains various test scenarios for duperscooper album mode.
+
+## Baseline Albums (16 folders)
+
+### AlbumA: "Dirty Deeds Done Dirt Cheap" by AC/DC (9 tracks)
+
+- `AlbumA-FLAC-with-MB` - FLAC 96kHz/24bit with MusicBrainz ID
+- `AlbumA-FLAC-no-MB` - FLAC 96kHz/24bit without any tags
+- `AlbumA-MP3-with-MB-320` - MP3 320kbps with MusicBrainz ID
+- `AlbumA-MP3-with-MB-128` - MP3 128kbps with MusicBrainz ID
+- `AlbumA-MP3-with-MB-064` - MP3 64kbps with MusicBrainz ID
+- `AlbumA-MP3-no-MB-320` - MP3 320kbps without any tags
+- `AlbumA-MP3-no-MB-128` - MP3 128kbps without any tags
+- `AlbumA-MP3-no-MB-064` - MP3 64kbps without any tags
+
+### AlbumB: "Spanking Machine" by Babes in Toyland
+
+(11 tracks originally, 10 in some copies)
+
+- `AlbumB-FLAC-with-MB` - FLAC 44.1kHz/16bit with MusicBrainz ID
+- `AlbumB-FLAC-no-MB` - FLAC 44.1kHz/16bit without any tags
+- `AlbumB-MP3-with-MB-320` - MP3 320kbps with MusicBrainz ID
+- `AlbumB-MP3-with-MB-128` - MP3 128kbps with MusicBrainz ID
+- `AlbumB-MP3-with-MB-064` - MP3 64kbps with MusicBrainz ID
+- `AlbumB-MP3-no-MB-320` - MP3 320kbps without any tags
+- `AlbumB-MP3-no-MB-128` - MP3 128kbps without any tags
+- `AlbumB-MP3-no-MB-064` - MP3 64kbps without any tags
+
+**Expected Result:** All 8 AlbumA folders should match as one group.
+All 8 AlbumB folders should match as one group.
+
+---
+
+## Test Scenario 1: Mixed MusicBrainz IDs Within Album
+
+### Scenario 1 Test Folders
+
+- `AlbumA-FLAC-MIXED-MB-IDs` - Tracks 1-2 have correct MB ID,
+  tracks 3-9 have different fake MB ID
+
+**Purpose:** Test detection of inconsistent MusicBrainz IDs within a
+single album
+
+**Expected Behavior:**
+
+- Should set `has_mixed_mb_ids=True`
+- Should NOT match by MusicBrainz Album ID (conflicting IDs)
+- Should fall back to fingerprint matching
+- Should still match with other AlbumA copies via fingerprints
+- Match method: "Acoustic Fingerprint" (not MB ID)
+
+---
+
+## Test Scenario 2: ID3 Tags Only (No MusicBrainz IDs)
+
+### Scenario 2 Test Folders
+
+- `AlbumA-MP3-ID3-ONLY-320` - MP3 320kbps with album/artist tags
+  but MB ID removed
+- `AlbumB-MP3-ID3-ONLY-320` - MP3 320kbps with album/artist tags
+  but MB ID removed
+
+**Purpose:** Test matching via ID3 album/artist tags when MusicBrainz
+IDs are absent
+
+**Expected Behavior:**
+
+- Should be treated as "canonical" (has album+artist metadata)
+- Should match with other AlbumA/AlbumB copies
+- Match method: "ID3 Album/Artist Tags"
+- Should contribute to matched_album and matched_artist identification
+
+---
+
+## Test Scenario 3: Partial Albums (Missing Tracks)
+
+### Scenario 3 Test Folders
+
+- `AlbumA-FLAC-PARTIAL-missing-2-tracks` - FLAC with only 7 tracks
+  (missing tracks 4 and 6)
+- `AlbumB-MP3-PARTIAL-missing-3-tracks` - MP3 128kbps with only
+  7 tracks (missing tracks 2, 8, 10)
+
+**Purpose:** Test that albums with different track counts are NOT
+incorrectly matched
+
+**Expected Behavior:**
+
+- Should NOT match with complete AlbumA copies (9 tracks ≠ 7 tracks)
+- Should NOT match with complete AlbumB copies (10/11 tracks ≠ 7 tracks)
+- Should NOT appear in duplicate groups (need 2+ albums with same
+  track count)
+- This is by design for Phase 1-5 (exact track count matching only)
+- Future Phase 6 will handle partial album detection
+
+---
+
+## Test Summary
+
+Total test folders: 16 baseline + 5 test scenarios = 21 folders
+
+Expected duplicate groups with current implementation:
+
+1. **AlbumA group** (9 tracks): 8 baseline + 1 ID3-only + 1 mixed-MB
+   = 10 albums
+2. **AlbumB group** (10 tracks): 8 baseline + 1 ID3-only = 9 albums
+3. **AlbumA partial** (7 tracks): No match (only 1 album)
+4. **AlbumB partial** (7 tracks): No match (only 1 album)
+
+The partial albums should be ignored in current output (< 2 albums in
+group).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,8 +38,11 @@ src/duperscooper/
 ├── __main__.py       # CLI interface (argparse), output formatting
 ├── cache.py          # CacheBackend interface, SQLite/JSON implementations
 ├── hasher.py         # AudioHasher: perceptual & exact hashing
-└── finder.py         # DuplicateFinder: search logic, parallelization
-                      # DuplicateManager: file operations
+├── finder.py         # DuplicateFinder: search logic, parallelization
+│                     # DuplicateManager: file operations
+└── album.py          # Album: dataclass for album metadata
+                      # AlbumScanner: album discovery and metadata extraction
+                      # AlbumDuplicateFinder: album duplicate detection
 ```
 
 ### Key Components
@@ -94,6 +97,41 @@ src/duperscooper/
   information
 - `format_file_size()`: Human-readable size strings
 - `get_file_info()`: File metadata for display
+
+#### Album (album.py)
+
+- `Album` (dataclass): Represents an album with metadata and fingerprints
+  - Fields: path, tracks, track_count, musicbrainz_albumid, album_name,
+    artist_name, total_size, avg_quality_score, fingerprints,
+    has_mixed_mb_ids, quality_info
+
+#### AlbumScanner (album.py)
+
+- `scan_albums()`: Discover all albums in given paths
+- `extract_album_metadata()`: Extract metadata from all tracks in album
+  directory
+- `get_musicbrainz_albumid()`: Extract MusicBrainz album ID via ffprobe
+- `get_album_tags()`: Extract album name and artist from metadata
+- Leverages existing AudioHasher for fingerprint caching
+- Non-recursive directory scan (one album = one directory)
+
+#### AlbumDuplicateFinder (album.py)
+
+- `find_duplicates()`: Find duplicate albums using specified strategy
+- `_match_by_musicbrainz()`: Group albums by MusicBrainz ID and track count
+- `_match_by_fingerprints()`: Group albums by perceptual fingerprint
+  similarity using Union-Find
+- `album_similarity()`: Calculate similarity percentage between two albums
+  (average track-by-track similarity)
+- `get_matched_album_info()`: Determine matched album name and artist for a
+  duplicate group (uses most common names)
+- `calculate_confidence()`: Calculate confidence that an album belongs to the
+  matched group
+  - MusicBrainz ID match: 100%
+  - Album/artist name match + fingerprints: 90-95%
+  - Fingerprint similarity only: 80-90%
+- Three matching strategies: `auto` (MB + fingerprint fallback),
+  `musicbrainz`, `fingerprint`
 
 ## Development Guidelines
 
@@ -191,6 +229,21 @@ duperscooper ~/Music --workers 1
 
 # Use legacy JSON cache backend instead of SQLite
 duperscooper ~/Music --cache-backend json
+
+# Album mode: Find duplicate albums
+duperscooper ~/Music --album-mode
+
+# Album mode with MusicBrainz-only matching
+duperscooper ~/Music --album-mode --album-match-strategy musicbrainz
+
+# Album mode with fingerprint-only matching
+duperscooper ~/Music --album-mode --album-match-strategy fingerprint
+
+# Album mode with JSON output (includes matched album/artist and confidence)
+duperscooper ~/Music --album-mode --output json
+
+# Album mode with CSV output (good for GUI integration)
+duperscooper ~/Music --album-mode --output csv > duplicate_albums.csv
 ```
 
 ### Debugging
@@ -324,6 +377,60 @@ All output formats now include quality information for duplicate groups:
   - Example: 320kbps MP3 = 320
 
 This ensures lossless files always rank higher than lossy, with finer granularity within each category.
+
+### Album Mode Output Formats
+
+Album mode adds matched album/artist identification and confidence scoring:
+
+- **Text Output** (default): Shows matched album/artist at group level, best quality album with `[Best]` marker, confidence percentage with color coding
+  ```
+  Group 1: Dirty Deeds by AC/DC
+  [Best] /music/ac-dc/dirty-deeds-flac (15 tracks, 450.2 MB)
+    Quality: FLAC 44.1kHz 16bit (avg)
+    Confidence: 100.0%
+    MusicBrainz ID: abc123...
+    Metadata: AC/DC - Dirty Deeds Done Dirt Cheap
+
+    /music/ac-dc/dirty-deeds-mp3 (15 tracks, 98.5 MB)
+    Quality: MP3 CBR 320kbps (avg)
+    Confidence: 95.0%
+    Match: 99.8%
+  ```
+
+- **JSON Output**: Includes `matched_album`, `matched_artist` at group level, `confidence` for each album
+  ```json
+  {
+    "matched_album": "Dirty Deeds Done Dirt Cheap",
+    "matched_artist": "AC/DC",
+    "albums": [
+      {
+        "path": "/music/ac-dc/dirty-deeds-flac",
+        "confidence": 100.0,
+        "is_best": true,
+        "quality_score": 11644.1,
+        ...
+      }
+    ]
+  }
+  ```
+
+- **CSV Output**: Adds columns for `matched_album`, `matched_artist`, `confidence`
+  - Format: `group_id,matched_album,matched_artist,album_path,track_count,total_size_bytes,total_size,quality_info,quality_score,confidence,is_best,musicbrainz_albumid,album_name,artist_name,has_mixed_mb_ids`
+  - Good for GUI integration and spreadsheet analysis
+
+### Album Confidence Scoring
+
+Confidence that an album belongs to a matched duplicate group:
+
+- **100%**: All albums have matching MusicBrainz album ID
+- **90-95%**: Album/artist metadata matches + high fingerprint similarity
+- **80-90%**: Fingerprint similarity only (no metadata match)
+
+Confidence calculation factors:
+- Base confidence: 80%
+- +5% if album name matches the group's matched album
+- +5% if artist name matches the group's matched artist
+- +0-10% based on average fingerprint similarity to other albums in group (98-100% similarity range)
 
 ## Future Enhancements
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -240,7 +240,7 @@ duperscooper ~/Music --album-mode --album-match-strategy musicbrainz
 duperscooper ~/Music --album-mode --album-match-strategy fingerprint
 
 # Album mode with JSON output (includes matched album/artist and confidence)
-duperscooper ~/Music --album-mode --output json
+duperscooper ~/Music --album-mode --output json > duplicate_albums.json
 
 # Album mode with CSV output (good for GUI integration)
 duperscooper ~/Music --album-mode --output csv > duplicate_albums.csv
@@ -347,14 +347,20 @@ duperscooper ~/Music --album-mode --output csv > duplicate_albums.csv
 
 All output formats now include quality information for duplicate groups:
 
-- **Text Output** (default): Shows best quality file first with `[Best]` marker, followed by duplicates with similarity percentage
-  ```
+- **Text Output** (default): Shows best quality file first with `[Best]`
+  marker, followed by duplicates with similarity percentage
+
+  ```text
   [Best] /path/to/file.flac (30.9 MB) - FLAC 44.1kHz 16bit
-    ├─ /path/to/file-320.mp3 (13.4 MB) - MP3 CBR 320kbps [99.9% match]
-    ├─ /path/to/file-192.mp3 (8.0 MB) - MP3 CBR 192kbps [99.8% match]
+    ├─ /path/to/file-320.mp3 (13.4 MB) - MP3 CBR 320kbps
+       [99.9% match]
+    ├─ /path/to/file-192.mp3 (8.0 MB) - MP3 CBR 192kbps
+       [99.8% match]
   ```
 
-- **JSON Output**: Includes `audio_info`, `quality_score`, `similarity_to_best`, and `is_best` fields
+- **JSON Output**: Includes `audio_info`, `quality_score`,
+  `similarity_to_best`, and `is_best` fields
+
   ```json
   {
     "path": "/path/to/file.flac",
@@ -365,25 +371,33 @@ All output formats now include quality information for duplicate groups:
   }
   ```
 
-- **CSV Output**: Adds columns for `audio_info`, `quality_score`, `similarity_to_best`, and `is_best`
+- **CSV Output**: Adds columns for `audio_info`, `quality_score`,
+  `similarity_to_best`, and `is_best`
 
-- **Interactive Delete**: Shows quality info for each file to help decide which duplicates to keep/delete
+- **Interactive Delete**: Shows quality info for each file to help decide
+  which duplicates to keep/delete
 
 ### Quality Scoring System
 
-- **Lossless formats** (FLAC, WAV, ALAC, etc.): `10000 + (bit_depth × 100) + (sample_rate / 1000)`
+- **Lossless formats** (FLAC, WAV, ALAC, etc.):
+  `10000 + (bit_depth × 100) + (sample_rate / 1000)`
   - Example: 24-bit 96kHz FLAC = 10000 + 2400 + 96 = 12496
 - **Lossy formats** (MP3, AAC, OGG, etc.): `bitrate / 1000` (in kbps)
   - Example: 320kbps MP3 = 320
 
-This ensures lossless files always rank higher than lossy, with finer granularity within each category.
+This ensures lossless files always rank higher than lossy, with finer
+granularity within each category.
 
 ### Album Mode Output Formats
 
-Album mode adds matched album/artist identification and confidence scoring:
+Album mode adds matched album/artist identification and confidence
+scoring:
 
-- **Text Output** (default): Shows matched album/artist at group level, best quality album with `[Best]` marker, confidence percentage with color coding
-  ```
+- **Text Output** (default): Shows matched album/artist at group level,
+  best quality album with `[Best]` marker, confidence percentage with
+  color coding
+
+  ```text
   Group 1: Dirty Deeds by AC/DC
   [Best] /music/ac-dc/dirty-deeds-flac (15 tracks, 450.2 MB)
     Quality: FLAC 44.1kHz 16bit (avg)
@@ -397,7 +411,9 @@ Album mode adds matched album/artist identification and confidence scoring:
     Match: 99.8%
   ```
 
-- **JSON Output**: Includes `matched_album`, `matched_artist` at group level, `confidence` for each album
+- **JSON Output**: Includes `matched_album`, `matched_artist` at group
+  level, `confidence` for each album
+
   ```json
   {
     "matched_album": "Dirty Deeds Done Dirt Cheap",
@@ -414,8 +430,12 @@ Album mode adds matched album/artist identification and confidence scoring:
   }
   ```
 
-- **CSV Output**: Adds columns for `matched_album`, `matched_artist`, `confidence`
-  - Format: `group_id,matched_album,matched_artist,album_path,track_count,total_size_bytes,total_size,quality_info,quality_score,confidence,is_best,musicbrainz_albumid,album_name,artist_name,has_mixed_mb_ids`
+- **CSV Output**: Adds columns for `matched_album`, `matched_artist`,
+  `confidence`
+  - Format: `group_id,matched_album,matched_artist,album_path,
+    track_count,total_size_bytes,total_size,quality_info,
+    quality_score,confidence,is_best,musicbrainz_albumid,
+    album_name,artist_name,has_mixed_mb_ids`
   - Good for GUI integration and spreadsheet analysis
 
 ### Album Confidence Scoring
@@ -423,14 +443,17 @@ Album mode adds matched album/artist identification and confidence scoring:
 Confidence that an album belongs to a matched duplicate group:
 
 - **100%**: All albums have matching MusicBrainz album ID
-- **90-95%**: Album/artist metadata matches + high fingerprint similarity
+- **90-95%**: Album/artist metadata matches + high fingerprint
+  similarity
 - **80-90%**: Fingerprint similarity only (no metadata match)
 
 Confidence calculation factors:
+
 - Base confidence: 80%
 - +5% if album name matches the group's matched album
 - +5% if artist name matches the group's matched artist
-- +0-10% based on average fingerprint similarity to other albums in group (98-100% similarity range)
+- +0-10% based on average fingerprint similarity to other albums in
+  group (98-100% similarity range)
 
 ## Future Enhancements
 
@@ -450,10 +473,14 @@ Confidence calculation factors:
 
 ### Album Mode Future Phases
 
-- **Fuzzy Tag Matching**: Match albums/tracks with possible misspellings in ID3 tags
-  - Use Levenshtein distance or similar algorithms to match album/artist names
-  - Example: "The Beatles" vs "Beatles" or "Led Zeppelin" vs "Led Zepplin"
-  - Match against canonical albums (those with MusicBrainz IDs) within close edit distance
+- **Fuzzy Tag Matching**: Match albums/tracks with possible misspellings
+  in ID3 tags
+  - Use Levenshtein distance or similar algorithms to match
+    album/artist names
+  - Example: "The Beatles" vs "Beatles" or "Led Zeppelin" vs
+    "Led Zepplin"
+  - Match against canonical albums (those with MusicBrainz IDs) within
+    close edit distance
   - Configurable threshold for fuzzy matching sensitivity
   - Useful for poorly tagged or user-edited metadata
 
@@ -503,11 +530,14 @@ fpcalc --version
 
 ## Notes for Claude
 
-- **Read `.claude-state.md` FIRST** before taking any actions - it contains complete session context, recent work, and current development state
+- **Read `.claude-state.md` FIRST** before taking any actions - it
+  contains complete session context, recent work, and current
+  development state
 - **Always format code** with Black before presenting to user
 - **Always run linting** with Ruff when making changes
 - **Prefer editing** existing files over creating new ones
 - **Test changes** when modifying core logic
 - **Document breaking changes** in commit messages
 - **Ask before** installing system packages or major refactors
-- **Reference files** using markdown links: `[file.py](src/duperscooper/file.py)`
+- **Reference files** using markdown links:
+  `[file.py](src/duperscooper/file.py)`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -484,6 +484,15 @@ Confidence calculation factors:
   - Configurable threshold for fuzzy matching sensitivity
   - Useful for poorly tagged or user-edited metadata
 
+- **Strict Fingerprint Mode**: Ultra-conservative duplicate detection
+  - Add `--strict` flag to ignore all metadata completely
+  - Use only acoustic fingerprint matching with high threshold (e.g.,
+    99.5%)
+  - Configurable with `--strict-threshold` option
+  - Useful for libraries with poor/inconsistent tagging
+  - Avoids false positives from metadata matches with different audio
+  - Quality control: verify MB ID matches are actually the same recording
+
 ## Git & GitHub
 
 ### Commit Guidelines

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -448,6 +448,15 @@ Confidence calculation factors:
 - Support for more exotic audio formats (AIFF, APE, etc.)
 - Optional fuzzy duration matching (±1 second tolerance)
 
+### Album Mode Future Phases
+
+- **Fuzzy Tag Matching**: Match albums/tracks with possible misspellings in ID3 tags
+  - Use Levenshtein distance or similar algorithms to match album/artist names
+  - Example: "The Beatles" vs "Beatles" or "Led Zeppelin" vs "Led Zepplin"
+  - Match against canonical albums (those with MusicBrainz IDs) within close edit distance
+  - Configurable threshold for fuzzy matching sensitivity
+  - Useful for poorly tagged or user-edited metadata
+
 ## Git & GitHub
 
 ### Commit Guidelines
@@ -494,6 +503,7 @@ fpcalc --version
 
 ## Notes for Claude
 
+- **Read `.claude-state.md` FIRST** before taking any actions - it contains complete session context, recent work, and current development state
 - **Always format code** with Black before presenting to user
 - **Always run linting** with Ruff when making changes
 - **Prefer editing** existing files over creating new ones

--- a/src/duperscooper/__main__.py
+++ b/src/duperscooper/__main__.py
@@ -617,6 +617,21 @@ def run_album_mode(args: argparse.Namespace) -> int:
         print("Album deletion not yet implemented (Phase 4)", file=sys.stderr)
         return 1
 
+    # Print cache statistics (text mode only)
+    if args.output == "text" and not args.no_progress:
+        # Track-level cache stats
+        cache_stats = hasher.get_cache_stats()
+        print(
+            f"\nTrack fingerprint cache: {cache_stats['hits']} hits, "
+            f"{cache_stats['misses']} misses, {cache_stats['size']} entries"
+        )
+
+        # Album-level cache stats
+        print(
+            f"Album metadata cache: {scanner.album_cache_hits} hits, "
+            f"{scanner.album_cache_misses} misses"
+        )
+
     # Format and output results
     if args.output == "json":
         format_album_output_json(duplicate_groups)

--- a/src/duperscooper/__main__.py
+++ b/src/duperscooper/__main__.py
@@ -211,6 +211,10 @@ def format_album_output_text(duplicate_groups: List[List]) -> None:
                 conf_color = Fore.LIGHTRED_EX
             print(f"    Confidence: {conf_color}{confidence:.1f}%{Style.RESET_ALL}")
 
+            # Match method
+            if album.match_method:
+                print(f"    Matched by: {album.match_method}")
+
             if album.musicbrainz_albumid:
                 print(f"    MusicBrainz ID: {album.musicbrainz_albumid}")
             if album.album_name or album.artist_name:
@@ -262,6 +266,7 @@ def format_album_output_json(duplicate_groups: List[List]) -> None:
                 "quality_info": album.quality_info,
                 "quality_score": album.avg_quality_score,
                 "confidence": confidence,
+                "match_method": album.match_method,
                 "is_best": album == best_album,
                 "musicbrainz_albumid": album.musicbrainz_albumid,
                 "album_name": album.album_name,
@@ -292,7 +297,8 @@ def format_album_output_csv(duplicate_groups: List[List]) -> None:
     print(
         "group_id,matched_album,matched_artist,album_path,track_count,"
         "total_size_bytes,total_size,quality_info,quality_score,confidence,"
-        "is_best,musicbrainz_albumid,album_name,artist_name,has_mixed_mb_ids"
+        "match_method,is_best,musicbrainz_albumid,album_name,artist_name,"
+        "has_mixed_mb_ids"
     )
 
     for idx, group in enumerate(duplicate_groups, 1):
@@ -320,7 +326,8 @@ def format_album_output_csv(duplicate_groups: List[List]) -> None:
                 f"{idx},{matched_album},{matched_artist},{album.path},"
                 f"{album.track_count},{album.total_size},{size_str},"
                 f"{album.quality_info},{album.avg_quality_score:.1f},"
-                f"{confidence:.1f},{is_best},{album.musicbrainz_albumid or ''},"
+                f"{confidence:.1f},{album.match_method or ''},"
+                f"{is_best},{album.musicbrainz_albumid or ''},"
                 f"{album.album_name or ''},{album.artist_name or ''},{has_mixed}"
             )
 

--- a/src/duperscooper/album.py
+++ b/src/duperscooper/album.py
@@ -1,0 +1,287 @@
+"""Album detection and metadata extraction for duplicate album finding."""
+
+import json
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+from .hasher import AudioHasher
+
+
+@dataclass
+class Album:
+    """Represents an album with metadata and fingerprints."""
+
+    path: Path  # Album directory path
+    tracks: List[Path]  # Audio files in album (sorted by name)
+    track_count: int  # Number of tracks
+    musicbrainz_albumid: Optional[str]  # MB album ID (if consistent across all tracks)
+    album_name: Optional[str]  # Album title from tags
+    artist_name: Optional[str]  # Artist from tags
+    total_size: int  # Sum of file sizes in bytes
+    avg_quality_score: float  # Average quality of tracks
+    fingerprints: List[List[int]]  # Perceptual fingerprints for each track
+    has_mixed_mb_ids: bool  # Flag if tracks have inconsistent MB IDs
+    quality_info: str  # e.g., "FLAC 44.1kHz 16bit (avg)"
+
+
+class AlbumScanner:
+    """Scans directories to identify albums and extract metadata."""
+
+    def __init__(self, hasher: AudioHasher, verbose: bool = False):
+        """
+        Initialize album scanner.
+
+        Args:
+            hasher: AudioHasher instance for fingerprinting
+            verbose: Enable verbose output
+        """
+        self.hasher = hasher
+        self.verbose = verbose
+
+    def scan_albums(self, paths: List[Path], max_workers: int = 8) -> List[Album]:
+        """
+        Discover all albums in given paths.
+
+        Args:
+            paths: List of paths to search for albums
+            max_workers: Number of worker threads for parallel fingerprinting
+
+        Returns:
+            List of Album objects
+        """
+        if self.verbose:
+            print("Discovering album directories...")
+
+        # Find all directories containing audio files
+        album_dirs = self._find_album_directories(paths)
+
+        if self.verbose:
+            print(f"Found {len(album_dirs)} album directories")
+
+        # Extract metadata and fingerprints for each album
+        albums = []
+        for idx, album_dir in enumerate(album_dirs, 1):
+            if self.verbose and idx % 100 == 0:
+                print(f"Processing album {idx}/{len(album_dirs)}...")
+
+            try:
+                album = self.extract_album_metadata(album_dir)
+                albums.append(album)
+            except Exception as e:
+                if self.verbose:
+                    print(f"Error processing {album_dir}: {e}")
+
+        if self.verbose:
+            print(f"Successfully processed {len(albums)} albums")
+
+        return albums
+
+    def _find_album_directories(self, paths: List[Path]) -> List[Path]:
+        """
+        Find all directories that contain audio files.
+
+        Args:
+            paths: List of paths to search
+
+        Returns:
+            List of directory paths containing audio files
+        """
+        album_dirs = set()
+
+        for path in paths:
+            if not path.exists():
+                continue
+
+            if path.is_file():
+                # If single file, use its parent directory
+                if self.hasher.is_audio_file(path):
+                    album_dirs.add(path.parent)
+            elif path.is_dir():
+                # Recursively find all directories with audio files
+                for file_path in path.rglob("*"):
+                    if file_path.is_file() and self.hasher.is_audio_file(file_path):
+                        album_dirs.add(file_path.parent)
+
+        return sorted(album_dirs)
+
+    def extract_album_metadata(self, album_path: Path) -> Album:
+        """
+        Extract metadata from all tracks in an album directory.
+
+        Args:
+            album_path: Path to album directory
+
+        Returns:
+            Album object with metadata and fingerprints
+        """
+        # Find all audio files in directory (non-recursive)
+        tracks = sorted(
+            [
+                f
+                for f in album_path.iterdir()
+                if f.is_file() and self.hasher.is_audio_file(f)
+            ]
+        )
+
+        if not tracks:
+            raise ValueError(f"No audio files found in {album_path}")
+
+        # Extract MusicBrainz album IDs from all tracks
+        mb_ids = []
+        for track in tracks:
+            mb_id = self.get_musicbrainz_albumid(track)
+            if mb_id:
+                mb_ids.append(mb_id)
+
+        # Check for consistency
+        unique_mb_ids = set(mb_ids)
+        has_mixed_mb_ids = len(unique_mb_ids) > 1
+        musicbrainz_albumid = None
+
+        if len(unique_mb_ids) == 1:
+            # All tracks have same MB ID
+            musicbrainz_albumid = unique_mb_ids.pop()
+        elif has_mixed_mb_ids and self.verbose:
+            print(f"Warning: {album_path} has mixed MusicBrainz IDs: {unique_mb_ids}")
+
+        # Extract album/artist names from first track as fallback
+        album_name, artist_name = self.get_album_tags(tracks[0])
+
+        # Get fingerprints for all tracks
+        fingerprints: List[List[int]] = []
+        total_size = 0
+        quality_scores = []
+
+        for track in tracks:
+            # Get fingerprint from cache or compute
+            fingerprint = self.hasher.compute_audio_hash(track, "perceptual")
+            # Type is List[int] because algorithm is "perceptual"
+            assert isinstance(fingerprint, list)
+            fingerprints.append(fingerprint)
+
+            # Get file size
+            total_size += track.stat().st_size
+
+            # Get quality metadata
+            try:
+                metadata = self.hasher.get_audio_metadata(track)
+                quality_score = self.hasher.calculate_quality_score(metadata)
+                quality_scores.append(quality_score)
+            except Exception:
+                quality_scores.append(0.0)
+
+        # Calculate average quality score
+        avg_quality_score = (
+            sum(quality_scores) / len(quality_scores) if quality_scores else 0.0
+        )
+
+        # Format quality info
+        try:
+            first_metadata = self.hasher.get_audio_metadata(tracks[0])
+            quality_info = self.hasher.format_audio_info(first_metadata) + " (avg)"
+        except Exception:
+            quality_info = "Unknown"
+
+        return Album(
+            path=album_path,
+            tracks=tracks,
+            track_count=len(tracks),
+            musicbrainz_albumid=musicbrainz_albumid,
+            album_name=album_name,
+            artist_name=artist_name,
+            total_size=total_size,
+            avg_quality_score=avg_quality_score,
+            fingerprints=fingerprints,
+            has_mixed_mb_ids=has_mixed_mb_ids,
+            quality_info=quality_info,
+        )
+
+    def get_musicbrainz_albumid(self, file_path: Path) -> Optional[str]:
+        """
+        Extract MusicBrainz album ID from audio file metadata.
+
+        Args:
+            file_path: Path to audio file
+
+        Returns:
+            MusicBrainz album ID or None if not found
+        """
+        try:
+            result = subprocess.run(
+                [
+                    "ffprobe",
+                    "-v",
+                    "quiet",
+                    "-print_format",
+                    "json",
+                    "-show_format",
+                    str(file_path),
+                ],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+
+            if result.returncode != 0:
+                return None
+
+            data = json.loads(result.stdout)
+            tags = data.get("format", {}).get("tags", {})
+
+            # Try common MusicBrainz tag names (case variations)
+            for key in tags:
+                if key.upper() == "MUSICBRAINZ_ALBUMID":
+                    return str(tags[key])
+
+            return None
+        except Exception:
+            return None
+
+    def get_album_tags(self, file_path: Path) -> Tuple[Optional[str], Optional[str]]:
+        """
+        Extract album name and artist from metadata.
+
+        Args:
+            file_path: Path to audio file
+
+        Returns:
+            Tuple of (album_name, artist_name), either may be None
+        """
+        try:
+            result = subprocess.run(
+                [
+                    "ffprobe",
+                    "-v",
+                    "quiet",
+                    "-print_format",
+                    "json",
+                    "-show_format",
+                    str(file_path),
+                ],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+
+            if result.returncode != 0:
+                return (None, None)
+
+            data = json.loads(result.stdout)
+            tags = data.get("format", {}).get("tags", {})
+
+            # Extract album and artist
+            album_name = None
+            artist_name = None
+
+            for key, value in tags.items():
+                key_upper = key.upper()
+                if key_upper in ("ALBUM", "ALBUM_TITLE"):
+                    album_name = value
+                elif key_upper in ("ARTIST", "ALBUM_ARTIST", "ALBUMARTIST"):
+                    artist_name = value
+
+            return (album_name, artist_name)
+        except Exception:
+            return (None, None)

--- a/src/duperscooper/cache.py
+++ b/src/duperscooper/cache.py
@@ -224,7 +224,7 @@ class SQLiteCacheBackend:
 
     def clear(self) -> bool:
         """
-        Clear all cache entries.
+        Clear all cache entries (fingerprints and albums).
 
         Returns:
             True if successful
@@ -232,6 +232,8 @@ class SQLiteCacheBackend:
         try:
             conn = self._get_connection()
             conn.execute("DELETE FROM fingerprint_cache")
+            conn.execute("DELETE FROM album_tracks")
+            conn.execute("DELETE FROM album_cache")
             conn.commit()
             with self._lock:
                 self._hits = 0

--- a/src/duperscooper/cache.py
+++ b/src/duperscooper/cache.py
@@ -5,7 +5,7 @@ import sqlite3
 import threading
 import time
 from pathlib import Path
-from typing import Dict, Optional, Protocol
+from typing import Any, Dict, List, Optional, Protocol, Tuple
 
 
 class CacheBackend(Protocol):
@@ -73,6 +73,8 @@ class SQLiteCacheBackend:
     def _init_db(self) -> None:
         """Initialize database schema."""
         conn = self._get_connection()
+
+        # Track fingerprint cache
         conn.execute(
             """
             CREATE TABLE IF NOT EXISTS fingerprint_cache (
@@ -89,6 +91,61 @@ class SQLiteCacheBackend:
             ON fingerprint_cache(last_accessed)
             """
         )
+
+        # Album cache for duplicate detection
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS album_cache (
+                album_path TEXT PRIMARY KEY,
+                track_count INTEGER NOT NULL,
+                musicbrainz_albumid TEXT,
+                album_name TEXT,
+                artist_name TEXT,
+                total_size INTEGER NOT NULL,
+                avg_quality_score REAL NOT NULL,
+                quality_info TEXT NOT NULL,
+                has_mixed_mb_ids INTEGER NOT NULL,
+                directory_mtime INTEGER NOT NULL,
+                created_at INTEGER NOT NULL,
+                last_accessed INTEGER NOT NULL
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_album_last_accessed
+            ON album_cache(last_accessed)
+            """
+        )
+        conn.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_album_mb_id
+            ON album_cache(musicbrainz_albumid)
+            WHERE musicbrainz_albumid IS NOT NULL
+            """
+        )
+
+        # Album tracks (for change detection)
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS album_tracks (
+                album_path TEXT NOT NULL,
+                track_path TEXT NOT NULL,
+                track_index INTEGER NOT NULL,
+                file_hash TEXT NOT NULL,
+                PRIMARY KEY (album_path, track_index),
+                FOREIGN KEY (album_path) REFERENCES album_cache(album_path)
+                    ON DELETE CASCADE
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_album_tracks_path
+            ON album_tracks(album_path)
+            """
+        )
+
         conn.commit()
 
     def get(self, key: str) -> Optional[str]:
@@ -188,6 +245,151 @@ class SQLiteCacheBackend:
         if hasattr(self._local, "conn"):
             self._local.conn.close()
             delattr(self._local, "conn")
+
+    def get_album(self, album_path: str) -> Optional[Dict[str, Any]]:
+        """
+        Get album from cache.
+
+        Args:
+            album_path: Path to album directory
+
+        Returns:
+            Album data dict or None if not cached or stale
+        """
+        conn = self._get_connection()
+        cursor = conn.execute(
+            """
+            SELECT track_count, musicbrainz_albumid, album_name, artist_name,
+                   total_size, avg_quality_score, quality_info, has_mixed_mb_ids,
+                   directory_mtime
+            FROM album_cache
+            WHERE album_path = ?
+            """,
+            (album_path,),
+        )
+        row = cursor.fetchone()
+
+        if not row:
+            return None
+
+        # Check if directory has been modified
+        from pathlib import Path
+
+        try:
+            current_mtime = int(Path(album_path).stat().st_mtime)
+            if current_mtime != row[8]:
+                # Directory modified, cache is stale
+                return None
+        except (OSError, FileNotFoundError):
+            return None
+
+        # Update last_accessed
+        conn.execute(
+            """
+            UPDATE album_cache
+            SET last_accessed = ?
+            WHERE album_path = ?
+            """,
+            (int(time.time()), album_path),
+        )
+        conn.commit()
+
+        # Get track list
+        cursor = conn.execute(
+            """
+            SELECT track_path, file_hash
+            FROM album_tracks
+            WHERE album_path = ?
+            ORDER BY track_index
+            """,
+            (album_path,),
+        )
+        tracks = [(row[0], row[1]) for row in cursor.fetchall()]
+
+        return {
+            "track_count": row[0],
+            "musicbrainz_albumid": row[1],
+            "album_name": row[2],
+            "artist_name": row[3],
+            "total_size": row[4],
+            "avg_quality_score": row[5],
+            "quality_info": row[6],
+            "has_mixed_mb_ids": bool(row[7]),
+            "directory_mtime": row[8],
+            "tracks": tracks,
+        }
+
+    def set_album(
+        self, album_path: str, album_data: Dict[str, Any], tracks: List[Tuple[str, str]]
+    ) -> None:
+        """
+        Store album in cache.
+
+        Args:
+            album_path: Path to album directory
+            album_data: Album metadata dict
+            tracks: List of (track_path, file_hash) tuples
+        """
+        conn = self._get_connection()
+        now = int(time.time())
+
+        # Insert or replace album
+        conn.execute(
+            """
+            INSERT OR REPLACE INTO album_cache (
+                album_path, track_count, musicbrainz_albumid, album_name,
+                artist_name, total_size, avg_quality_score, quality_info,
+                has_mixed_mb_ids, directory_mtime, created_at, last_accessed
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                album_path,
+                album_data["track_count"],
+                album_data.get("musicbrainz_albumid"),
+                album_data.get("album_name"),
+                album_data.get("artist_name"),
+                album_data["total_size"],
+                album_data["avg_quality_score"],
+                album_data["quality_info"],
+                int(album_data.get("has_mixed_mb_ids", False)),
+                album_data["directory_mtime"],
+                now,
+                now,
+            ),
+        )
+
+        # Delete old tracks
+        conn.execute("DELETE FROM album_tracks WHERE album_path = ?", (album_path,))
+
+        # Insert tracks
+        for idx, (track_path, file_hash) in enumerate(tracks):
+            conn.execute(
+                """
+                INSERT INTO album_tracks (
+                    album_path, track_path, track_index, file_hash
+                )
+                VALUES (?, ?, ?, ?)
+                """,
+                (album_path, track_path, idx, file_hash),
+            )
+
+        conn.commit()
+
+    def clear_albums(self) -> bool:
+        """
+        Clear all album cache entries.
+
+        Returns:
+            True if successful
+        """
+        try:
+            conn = self._get_connection()
+            conn.execute("DELETE FROM album_tracks")
+            conn.execute("DELETE FROM album_cache")
+            conn.commit()
+            return True
+        except sqlite3.Error:
+            return False
 
     def cleanup_old(self, max_age_days: int = 90) -> int:
         """

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,11 +1,8 @@
 """Tests for cache backend implementations."""
 
 import json
-import sqlite3
 import tempfile
 from pathlib import Path
-
-import pytest
 
 from duperscooper.cache import (
     JSONCacheBackend,
@@ -17,7 +14,7 @@ from duperscooper.cache import (
 class TestSQLiteCacheBackend:
     """Tests for SQLite cache backend."""
 
-    def test_init_creates_database(self):
+    def test_init_creates_database(self) -> None:
         """Test that initialization creates database file."""
         with tempfile.TemporaryDirectory() as tmpdir:
             db_path = Path(tmpdir) / "test.db"
@@ -26,7 +23,7 @@ class TestSQLiteCacheBackend:
             assert db_path.exists()
             cache.close()
 
-    def test_set_and_get(self):
+    def test_set_and_get(self) -> None:
         """Test storing and retrieving values."""
         with tempfile.TemporaryDirectory() as tmpdir:
             db_path = Path(tmpdir) / "test.db"
@@ -39,7 +36,7 @@ class TestSQLiteCacheBackend:
             assert cache.get("key2") == "value2"
             cache.close()
 
-    def test_get_nonexistent(self):
+    def test_get_nonexistent(self) -> None:
         """Test getting a nonexistent key returns None."""
         with tempfile.TemporaryDirectory() as tmpdir:
             db_path = Path(tmpdir) / "test.db"
@@ -48,7 +45,7 @@ class TestSQLiteCacheBackend:
             assert cache.get("nonexistent") is None
             cache.close()
 
-    def test_get_stats(self):
+    def test_get_stats(self) -> None:
         """Test cache statistics tracking."""
         with tempfile.TemporaryDirectory() as tmpdir:
             db_path = Path(tmpdir) / "test.db"
@@ -80,7 +77,7 @@ class TestSQLiteCacheBackend:
 
             cache.close()
 
-    def test_clear(self):
+    def test_clear(self) -> None:
         """Test clearing all cache entries."""
         with tempfile.TemporaryDirectory() as tmpdir:
             db_path = Path(tmpdir) / "test.db"
@@ -102,7 +99,7 @@ class TestSQLiteCacheBackend:
 
             cache.close()
 
-    def test_persistence(self):
+    def test_persistence(self) -> None:
         """Test that data persists across backend instances."""
         with tempfile.TemporaryDirectory() as tmpdir:
             db_path = Path(tmpdir) / "test.db"
@@ -117,7 +114,7 @@ class TestSQLiteCacheBackend:
             assert cache2.get("key1") == "value1"
             cache2.close()
 
-    def test_cleanup_old(self):
+    def test_cleanup_old(self) -> None:
         """Test removing old cache entries."""
         with tempfile.TemporaryDirectory() as tmpdir:
             db_path = Path(tmpdir) / "test.db"
@@ -148,7 +145,7 @@ class TestSQLiteCacheBackend:
 class TestJSONCacheBackend:
     """Tests for JSON cache backend."""
 
-    def test_set_and_get(self):
+    def test_set_and_get(self) -> None:
         """Test storing and retrieving values."""
         with tempfile.TemporaryDirectory() as tmpdir:
             json_path = Path(tmpdir) / "test.json"
@@ -161,7 +158,7 @@ class TestJSONCacheBackend:
             assert cache.get("key2") == "value2"
             cache.close()
 
-    def test_get_nonexistent(self):
+    def test_get_nonexistent(self) -> None:
         """Test getting a nonexistent key returns None."""
         with tempfile.TemporaryDirectory() as tmpdir:
             json_path = Path(tmpdir) / "test.json"
@@ -170,7 +167,7 @@ class TestJSONCacheBackend:
             assert cache.get("nonexistent") is None
             cache.close()
 
-    def test_get_stats(self):
+    def test_get_stats(self) -> None:
         """Test cache statistics tracking."""
         with tempfile.TemporaryDirectory() as tmpdir:
             json_path = Path(tmpdir) / "test.json"
@@ -194,7 +191,7 @@ class TestJSONCacheBackend:
 
             cache.close()
 
-    def test_clear(self):
+    def test_clear(self) -> None:
         """Test clearing all cache entries."""
         with tempfile.TemporaryDirectory() as tmpdir:
             json_path = Path(tmpdir) / "test.json"
@@ -214,7 +211,7 @@ class TestJSONCacheBackend:
 
             cache.close()
 
-    def test_persistence(self):
+    def test_persistence(self) -> None:
         """Test that data persists across backend instances."""
         with tempfile.TemporaryDirectory() as tmpdir:
             json_path = Path(tmpdir) / "test.json"
@@ -229,7 +226,7 @@ class TestJSONCacheBackend:
             assert cache2.get("key1") == "value1"
             cache2.close()
 
-    def test_load_existing(self):
+    def test_load_existing(self) -> None:
         """Test loading existing JSON cache file."""
         with tempfile.TemporaryDirectory() as tmpdir:
             json_path = Path(tmpdir) / "test.json"
@@ -248,7 +245,7 @@ class TestJSONCacheBackend:
 class TestMigration:
     """Tests for JSON to SQLite migration."""
 
-    def test_migrate_json_to_sqlite(self):
+    def test_migrate_json_to_sqlite(self) -> None:
         """Test migrating data from JSON to SQLite."""
         with tempfile.TemporaryDirectory() as tmpdir:
             json_path = Path(tmpdir) / "hashes.json"
@@ -276,7 +273,7 @@ class TestMigration:
 
             sqlite_cache.close()
 
-    def test_migrate_nonexistent_json(self):
+    def test_migrate_nonexistent_json(self) -> None:
         """Test migrating when JSON file doesn't exist."""
         with tempfile.TemporaryDirectory() as tmpdir:
             json_path = Path(tmpdir) / "nonexistent.json"
@@ -285,7 +282,7 @@ class TestMigration:
             migrated = migrate_json_to_sqlite(json_path, db_path)
             assert migrated == 0
 
-    def test_migrate_empty_json(self):
+    def test_migrate_empty_json(self) -> None:
         """Test migrating empty JSON cache."""
         with tempfile.TemporaryDirectory() as tmpdir:
             json_path = Path(tmpdir) / "hashes.json"


### PR DESCRIPTION
## Summary

Implements album-level duplicate detection with multiple matching strategies and quality scoring. Users can now find duplicate albums (entire directories) in addition to individual track duplicates.

### Key Features

- **Album Detection**: Non-recursive directory scan treats each folder as an album
- **Three Matching Strategies**:
  - `auto` (default): Canonical matching (MusicBrainz ID → ID3 tags → fingerprints)
  - `musicbrainz`: Match only by MusicBrainz Album ID + track count
  - `fingerprint`: Match only by acoustic fingerprint similarity
- **Match Method Display**: Shows how each album was matched (MB ID / ID3 tags / fingerprint)
- **Confidence Scoring**: 80-100% confidence based on match method and metadata quality
- **Quality Detection**: Identifies best quality album in each duplicate group
- **Album Cache**: SQLite-backed caching of album metadata for fast repeated scans
- **Output Formats**: Enhanced text, JSON, and CSV output with album-specific info

### Technical Implementation

**New Module**: [src/duperscooper/album.py](src/duperscooper/album.py)
- `Album` dataclass: Album metadata and fingerprints
- `AlbumScanner`: Album discovery and metadata extraction
- `AlbumDuplicateFinder`: Duplicate detection with multiple strategies

**Enhanced Module**: [src/duperscooper/cache.py](src/duperscooper/cache.py)
- Added `album_cache` and `album_tracks` tables
- Directory mtime-based cache invalidation
- Thread-safe album caching (WAL mode)

**CLI Integration**: [src/duperscooper/__main__.py](src/duperscooper/__main__.py)
- Added `--album-mode` flag
- Added `--album-match-strategy` option (auto/musicbrainz/fingerprint)
- Enhanced all output formatters for album mode

### Matching Algorithm

The `auto` strategy uses a canonical matching approach:

1. **Identify Canonical Albums**: Albums with MusicBrainz IDs or complete ID3 tags
2. **Fingerprint Grouping**: Group albums by acoustic similarity (default ≥98%)
3. **Metadata Merging**: Merge groups by shared MusicBrainz IDs
4. **Untagged Matching**: Match untagged albums against canonical groups
5. **Name Inheritance**: Untagged albums inherit canonical album/artist names

This ensures albums with different tagging states (MB ID / ID3 only / untagged) still group together correctly.

### Example Usage

```bash
# Find duplicate albums
duperscooper ~/Music --album-mode

# MusicBrainz-only matching
duperscooper ~/Music --album-mode --album-match-strategy musicbrainz

# JSON output for GUI integration
duperscooper ~/Music --album-mode --output json > albums.json
```

### Example Output

```
Group 1: Dirty Deeds Done Dirt Cheap by AC/DC
[Best] /music/ac-dc/dirty-deeds-flac (9 tracks, 872.5 MB)
    Quality: FLAC 96.0kHz 24bit (avg)
    Confidence: 100.0%
    Matched by: MusicBrainz Album ID
    MusicBrainz ID: db2015bc-768c-43b8-a65e-2242102bacb8
    Metadata: AC/DC - Dirty Deeds Done Dirt Cheap

  /music/ac-dc/dirty-deeds-mp3 (9 tracks, 95.7 MB)
    Quality: MP3 CBR 320kbps (avg)
    Confidence: 96.8%
    Matched by: ID3 Album/Artist Tags
    Match: 99.9%
```

### Test Coverage

Created comprehensive test scenarios in `test-albums/`:
- 16 baseline albums (2 albums × 8 variants each)
- Mixed MusicBrainz IDs (some tracks tagged, some not)
- ID3-only albums (MusicBrainz IDs removed)
- Partial albums (missing tracks)
- All scenarios documented in [ALBUM-TEST-SCENARIOS.md](ALBUM-TEST-SCENARIOS.md)

### Performance

- Album cache provides ~2-3x speedup on repeated scans
- Parallel fingerprinting (8 workers) leverages existing multithreading infrastructure
- Efficient Union-Find algorithm for grouping (O(n²) for fingerprint comparisons)

## Breaking Changes

None - this is a new feature activated with `--album-mode` flag. Track mode remains default and unchanged.

## Future Enhancements

- **Phase 5**: Interactive album deletion
- **Phase 6**: Partial album detection (match albums with missing tracks)
- **Phase 7**: Fuzzy tag matching (handle misspellings in metadata)

## Testing

```bash
# Run all tests
.venv/bin/pytest tests/ -v

# Test album mode
.venv/bin/duperscooper --album-mode test-albums/

# Test all matching strategies
.venv/bin/duperscooper --album-mode --album-match-strategy musicbrainz test-albums/
.venv/bin/duperscooper --album-mode --album-match-strategy fingerprint test-albums/
.venv/bin/duperscooper --album-mode --album-match-strategy auto test-albums/
```

## Documentation Updates

- Updated [CLAUDE.md](CLAUDE.md) with album mode architecture and usage
- Added [ALBUM-TEST-SCENARIOS.md](ALBUM-TEST-SCENARIOS.md) with test documentation
- Updated [.claude-state.md](.claude-state.md) with development history