### PR TITLE
Add bash/zsh/tcsh tab completion support

### DIFF
--- a/.claude-state.md
+++ b/.claude-state.md
@@ -1,8 +1,8 @@
 # Claude Development State - duperscooper
 
-**Last Updated:** 2025-10-01
-**Current Branch:** feature/album-mode
-**Latest Commit:** f592888 - feat(album): display match method for each album
+**Last Updated:** 2025-10-02
+**Current Branch:** main
+**Latest Commit:** (on main after merging album-mode)
 
 ## Project Overview
 
@@ -421,7 +421,49 @@ duperscooper ~/Music --album-mode --output csv > albums.csv
 - ✅ Group sorting by average match percentage (highest quality matches first)
 - ✅ Tested with partial albums (7/9 tracks, 7/11 tracks)
 
-### Phase 6: Interactive Album Deletion (Next - Pending)
+### Phase 6: Tab Completion ✅ (COMPLETED)
+
+**Objective:** Implement bash/zsh/tcsh tab completion for duperscooper command-line options.
+
+**Status:** Completed - Pending PR
+
+**Completed Tasks:**
+
+- ✅ Extracted `get_parser()` function in `src/duperscooper/__main__.py` for shtab import
+- ✅ Created `install-completion.sh` script for automatic installation
+- ✅ Created `uninstall-completion.sh` script for cleanup
+- ✅ Added `shtab>=1.7.0` to `pyproject.toml` as optional dependency
+- ✅ Added `shtab==1.7.1` to `requirements.txt`
+- ✅ Updated `CLAUDE.md` with tab completion documentation
+- ✅ Verified shtab can generate completion scripts successfully
+- ✅ All quality checks passed (Black, Ruff, MyPy)
+
+**Implementation Details:**
+
+- Uses shtab's static completion script generation (faster than dynamic)
+- External shell scripts call `shtab --shell=bash duperscooper.__main__.get_parser`
+- Supports bash, zsh, and tcsh shells
+- Auto-detects shell or accepts explicit argument
+- Completion is optional - doesn't affect normal duperscooper usage
+- No performance impact (static scripts generated once)
+
+**Usage:**
+
+```bash
+# Install shtab (optional dependency)
+pip install shtab
+
+# Install tab completion
+./install-completion.sh bash  # or zsh, tcsh
+
+# Test it
+duperscooper --al<TAB>  # completes to --album-mode, --album-match-strategy, etc.
+
+# Uninstall
+./uninstall-completion.sh bash
+```
+
+### Phase 7: Interactive Album Deletion (Next - Pending)
 
 **Objective:** Allow users to interactively delete duplicate albums.
 
@@ -433,7 +475,7 @@ duperscooper ~/Music --album-mode --output csv > albums.csv
 - Allow preview of album contents before deletion
 - Confirm deletion of directories (not just files)
 
-### Phase 7: Fuzzy Tag Matching (Future - from CLAUDE.md)
+### Phase 8: Fuzzy Tag Matching (Future - from CLAUDE.md)
 
 **Objective:** Match albums with misspelled metadata.
 
@@ -445,7 +487,7 @@ duperscooper ~/Music --album-mode --output csv > albums.csv
 - Configurable fuzzy matching sensitivity
 - Useful for poorly tagged or user-edited metadata
 
-### Phase 8: Strict Fingerprint Mode (Future)
+### Phase 9: Strict Fingerprint Mode (Future)
 
 **Objective:** Ultra-conservative duplicate detection that ignores metadata entirely.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -253,6 +253,72 @@ duperscooper ~/Music --album-mode --output csv > duplicate_albums.csv
 - Add `print()` statements in code (not in production)
 - Use `pytest -v -s` to see print output in tests
 
+## Tab Completion (Optional)
+
+duperscooper supports bash and zsh tab completion for all command-line options.
+
+### Installation
+
+1. **Install shtab** (required for completion generation):
+
+   ```bash
+   pip install shtab
+   # OR
+   pip install duperscooper[completion]
+   ```
+
+2. **Run installation script**:
+
+   ```bash
+   ./install-completion.sh        # Auto-detects your shell
+   # OR
+   ./install-completion.sh bash   # Explicitly specify bash
+   ./install-completion.sh zsh    # Explicitly specify zsh
+   ```
+
+3. **Restart your shell** or source the completion file
+
+### Usage
+
+Once installed, tab completion will work for all options:
+
+```bash
+duperscooper --al<TAB>
+# Completes to: --album-mode, --album-match-strategy, --allow-partial-albums
+
+duperscooper --album-match-strategy <TAB>
+# Shows: auto  fingerprint  musicbrainz
+
+duperscooper --output <TAB>
+# Shows: csv  json  text
+
+duperscooper --cache-backend <TAB>
+# Shows: json  sqlite
+```
+
+### Uninstallation
+
+```bash
+./uninstall-completion.sh
+```
+
+### Manual Installation
+
+If the script doesn't work, you can manually generate and install:
+
+**Bash:**
+
+```bash
+shtab --shell=bash duperscooper.__main__.get_parser > ~/.local/share/bash-completion/completions/duperscooper
+```
+
+**Zsh:**
+
+```bash
+shtab --shell=zsh duperscooper.__main__.get_parser > ~/.zsh/completions/_duperscooper
+# Ensure ~/.zsh/completions is in your $fpath
+```
+
 ## Error Handling
 
 ### Expected Behaviors

--- a/install-completion.sh
+++ b/install-completion.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+# Install bash/zsh tab completion for duperscooper
+
+set -e
+
+# Detect shell
+SHELL_NAME="${1:-$(basename "$SHELL")}"
+
+echo "Installing tab completion for $SHELL_NAME..."
+
+# Check if shtab is installed
+if ! python -c "import shtab" 2>/dev/null; then
+    echo "Error: shtab is not installed"
+    echo "Install it with: pip install shtab"
+    exit 1
+fi
+
+# Check if duperscooper is installed
+if ! python -c "import duperscooper" 2>/dev/null; then
+    echo "Error: duperscooper is not installed"
+    echo "Install it with: pip install -e ."
+    exit 1
+fi
+
+case "$SHELL_NAME" in
+    bash)
+        # Try user directory first, fall back to system
+        if [ -d "$HOME/.local/share/bash-completion/completions" ]; then
+            COMPLETION_DIR="$HOME/.local/share/bash-completion/completions"
+            SUDO=""
+        elif [ -d "/usr/share/bash-completion/completions" ]; then
+            COMPLETION_DIR="/usr/share/bash-completion/completions"
+            SUDO="sudo"
+        else
+            echo "Error: Could not find bash completion directory"
+            echo "Creating user completion directory..."
+            mkdir -p "$HOME/.local/share/bash-completion/completions"
+            COMPLETION_DIR="$HOME/.local/share/bash-completion/completions"
+            SUDO=""
+        fi
+
+        echo "Generating bash completion script..."
+        shtab --shell=bash duperscooper.__main__.get_parser | \
+            $SUDO tee "$COMPLETION_DIR/duperscooper" > /dev/null
+
+        echo "✓ Bash completion installed to $COMPLETION_DIR/duperscooper"
+        echo ""
+        echo "Restart your shell or run:"
+        echo "  source $COMPLETION_DIR/duperscooper"
+        ;;
+
+    zsh)
+        # Try user directory first, fall back to system
+        if [ -d "$HOME/.zsh/completions" ]; then
+            COMPLETION_DIR="$HOME/.zsh/completions"
+            SUDO=""
+        elif [ -d "/usr/local/share/zsh/site-functions" ]; then
+            COMPLETION_DIR="/usr/local/share/zsh/site-functions"
+            SUDO="sudo"
+        else
+            echo "Creating user completion directory..."
+            mkdir -p "$HOME/.zsh/completions"
+            COMPLETION_DIR="$HOME/.zsh/completions"
+            SUDO=""
+            echo ""
+            echo "Note: Add this to your ~/.zshrc if not already present:"
+            echo "  fpath=(~/.zsh/completions \$fpath)"
+            echo "  autoload -Uz compinit && compinit"
+            echo ""
+        fi
+
+        echo "Generating zsh completion script..."
+        shtab --shell=zsh duperscooper.__main__.get_parser | \
+            $SUDO tee "$COMPLETION_DIR/_duperscooper" > /dev/null
+
+        echo "✓ Zsh completion installed to $COMPLETION_DIR/_duperscooper"
+        echo ""
+        echo "Restart your shell or run:"
+        echo "  autoload -Uz compinit && compinit"
+        ;;
+
+    tcsh)
+        COMPLETION_DIR="$HOME/.tcsh/completions"
+        mkdir -p "$COMPLETION_DIR"
+
+        echo "Generating tcsh completion script..."
+        shtab --shell=tcsh duperscooper.__main__.get_parser > \
+            "$COMPLETION_DIR/duperscooper.completion.csh"
+
+        echo "✓ Tcsh completion installed to $COMPLETION_DIR/duperscooper.completion.csh"
+        echo ""
+        echo "Add to ~/.tcshrc:"
+        echo "  source $COMPLETION_DIR/duperscooper.completion.csh"
+        ;;
+
+    *)
+        echo "Error: Unsupported shell '$SHELL_NAME'"
+        echo "Supported shells: bash, zsh, tcsh"
+        echo ""
+        echo "Usage: $0 [bash|zsh|tcsh]"
+        exit 1
+        ;;
+esac
+
+echo ""
+echo "Tab completion installed successfully!"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,9 @@ dependencies = [
     "colorama>=0.4.6",
 ]
 
+[project.optional-dependencies]
+completion = ["shtab>=1.7.0"]
+
 [project.scripts]
 duperscooper = "duperscooper.__main__:main"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,6 @@ ruff==0.6.3
 mypy==1.11.2
 pytest==8.3.2
 pytest-cov==5.0.0
+
+# Completion generation (optional)
+shtab==1.7.1

--- a/src/duperscooper/__main__.py
+++ b/src/duperscooper/__main__.py
@@ -46,7 +46,9 @@ def _calculate_track_group_avg_match(file_list: List[tuple], hasher: Any) -> flo
 
     # Extract similarities
     # (enriched_files format: (path, size, info, score, similarity))
-    similarities = [float(entry[4]) for entry in enriched_files]  # entry[4] is similarity
+    similarities = [
+        float(entry[4]) for entry in enriched_files
+    ]  # entry[4] is similarity
     return float(sum(similarities) / len(similarities)) if similarities else 0.0
 
 
@@ -489,8 +491,16 @@ def format_output_csv(duplicates: Dict[str, List[tuple]]) -> None:
             )
 
 
-def parse_args() -> argparse.Namespace:
-    """Parse command line arguments."""
+def get_parser() -> argparse.ArgumentParser:
+    """
+    Get the argument parser for duperscooper.
+
+    This function is used by tab completion tools (e.g., shtab) to generate
+    completion scripts.
+
+    Returns:
+        ArgumentParser configured with all duperscooper options
+    """
     parser = argparse.ArgumentParser(
         prog="duperscooper",
         description="Find duplicate audio files recursively in given paths.",
@@ -634,6 +644,12 @@ Examples:
         version=f"%(prog)s {__version__}",
     )
 
+    return parser
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command line arguments."""
+    parser = get_parser()
     return parser.parse_args()
 
 

--- a/uninstall-completion.sh
+++ b/uninstall-completion.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# Uninstall bash/zsh tab completion for duperscooper
+
+SHELL_NAME="${1:-$(basename "$SHELL")}"
+
+echo "Uninstalling tab completion for $SHELL_NAME..."
+
+case "$SHELL_NAME" in
+    bash)
+        REMOVED=false
+        if [ -f "$HOME/.local/share/bash-completion/completions/duperscooper" ]; then
+            rm "$HOME/.local/share/bash-completion/completions/duperscooper"
+            echo "✓ Removed user completion: $HOME/.local/share/bash-completion/completions/duperscooper"
+            REMOVED=true
+        fi
+        if [ -f "/usr/share/bash-completion/completions/duperscooper" ]; then
+            sudo rm "/usr/share/bash-completion/completions/duperscooper"
+            echo "✓ Removed system completion: /usr/share/bash-completion/completions/duperscooper"
+            REMOVED=true
+        fi
+        if [ "$REMOVED" = false ]; then
+            echo "No bash completion found"
+            exit 1
+        fi
+        ;;
+
+    zsh)
+        REMOVED=false
+        if [ -f "$HOME/.zsh/completions/_duperscooper" ]; then
+            rm "$HOME/.zsh/completions/_duperscooper"
+            echo "✓ Removed user completion: $HOME/.zsh/completions/_duperscooper"
+            REMOVED=true
+        fi
+        if [ -f "/usr/local/share/zsh/site-functions/_duperscooper" ]; then
+            sudo rm "/usr/local/share/zsh/site-functions/_duperscooper"
+            echo "✓ Removed system completion: /usr/local/share/zsh/site-functions/_duperscooper"
+            REMOVED=true
+        fi
+        if [ "$REMOVED" = false ]; then
+            echo "No zsh completion found"
+            exit 1
+        fi
+        ;;
+
+    tcsh)
+        if [ -f "$HOME/.tcsh/completions/duperscooper.completion.csh" ]; then
+            rm "$HOME/.tcsh/completions/duperscooper.completion.csh"
+            echo "✓ Removed tcsh completion: $HOME/.tcsh/completions/duperscooper.completion.csh"
+        else
+            echo "No tcsh completion found"
+            exit 1
+        fi
+        ;;
+
+    *)
+        echo "Error: Unsupported shell '$SHELL_NAME'"
+        echo "Supported shells: bash, zsh, tcsh"
+        echo ""
+        echo "Usage: $0 [bash|zsh|tcsh]"
+        exit 1
+        ;;
+esac
+
+echo ""
+echo "Tab completion uninstalled successfully!"
+echo "Restart your shell for changes to take effect."


### PR DESCRIPTION
## Summary

Implements optional tab completion for duperscooper command-line options using shtab. This allows users to tab-complete options like `--al<TAB>` to `--album-mode` or `--album-match-strategy`.

**Phase 6 of the duperscooper roadmap.**

## Changes

- **Extracted `get_parser()` function** in `src/duperscooper/__main__.py`
  - Allows shtab to import the ArgumentParser for completion generation
  - `parse_args()` now calls `get_parser()` then parses arguments
  
- **Added installation script** (`install-completion.sh`)
  - Auto-detects shell (bash/zsh/tcsh) or accepts explicit argument
  - Generates static completion scripts via shtab CLI
  - Installs to appropriate completion directories
  - Handles both user and system-wide installation paths
  
- **Added uninstallation script** (`uninstall-completion.sh`)
  - Removes completion files from standard directories
  
- **Dependencies**
  - Added `shtab>=1.7.0` to `pyproject.toml` as optional dependency
  - Added `shtab==1.7.1` to `requirements.txt`
  
- **Documentation**
  - Updated `CLAUDE.md` with tab completion section
  - Updated `.claude-state.md` to mark Phase 6 as completed

## Implementation Details

- Uses **static completion scripts** (faster than dynamic approaches like argcomplete)
- External shell scripts call `shtab --shell=bash duperscooper.__main__.get_parser`
- Supports bash, zsh, and tcsh shells
- Completion is **completely optional** - doesn't affect normal duperscooper usage
- No performance impact (scripts generated once, not on each tab press)

## Usage

```bash
# Install shtab (optional dependency)
pip install shtab

# Install tab completion for your shell
./install-completion.sh bash  # or zsh, tcsh

# Restart your shell, then test
duperscooper --al<TAB>
# Completes to: --album-mode, --album-match-strategy, --allow-partial-albums

# Uninstall
./uninstall-completion.sh bash
```

## Testing

- ✅ Verified `get_parser()` can be imported by shtab
- ✅ Verified shtab generates valid completion scripts
- ✅ All code quality checks passed (Black, Ruff, MyPy)

## Test plan

- [ ] Install shtab in a clean environment
- [ ] Run `./install-completion.sh bash` and verify installation
- [ ] Open new shell and test tab completion on `--al<TAB>`, `--out<TAB>`, etc.
- [ ] Verify all command-line options complete correctly
- [ ] Run `./uninstall-completion.sh bash` and verify cleanup
- [ ] Test with zsh and tcsh if available