### PR TITLE
feat: add progress bar for album scanning phase

### DIFF
--- a/src/duperscooper/album.py
+++ b/src/duperscooper/album.py
@@ -62,26 +62,39 @@ class AlbumScanner:
             List of Album objects
         """
         if self.verbose:
-            print("Discovering album directories...")
+            print("Discovering album directories...", flush=True)
 
         # Find all directories containing audio files
         album_dirs = self._find_album_directories(paths)
 
         if self.verbose:
-            print(f"Found {len(album_dirs)} album directories")
+            print(f"Found {len(album_dirs)} album directories", flush=True)
 
         # Extract metadata and fingerprints for each album
         albums = []
-        for idx, album_dir in enumerate(album_dirs, 1):
-            if self.verbose and idx % 100 == 0:
-                print(f"Processing album {idx}/{len(album_dirs)}...")
 
+        if self.verbose:
+            from tqdm import tqdm
+
+            iterator = tqdm(
+                album_dirs,
+                desc="Scanning albums",
+                unit="album",
+                disable=False,
+            )
+        else:
+            iterator = album_dirs
+
+        for album_dir in iterator:
             try:
                 album = self.extract_album_metadata(album_dir)
                 albums.append(album)
             except Exception as e:
                 if self.verbose:
-                    print(f"Error processing {album_dir}: {e}")
+                    # tqdm.write prints without disrupting progress bar
+                    from tqdm import tqdm
+
+                    tqdm.write(f"Error processing {album_dir}: {e}")
 
         if self.verbose:
             print(f"Successfully processed {len(albums)} albums")


### PR DESCRIPTION
## Summary

Adds a tqdm progress bar during the album scanning phase to provide visual feedback for long-running operations.

## Problem

When scanning albums, there was a gap in visual feedback between these two messages:
```
Found 21 album directories
Successfully processed 21 albums
```

For large libraries, this phase can take minutes without any indication of progress or ETA.

## Solution

Added tqdm progress bar that shows:
- Current album being processed (count)
- Percentage complete
- Processing rate (albums/second)
- Estimated time remaining

```
Discovering album directories...
Found 21 album directories
Scanning albums: 100%|██████████| 21/21 [00:33<00:00, 1.61s/album]
Successfully processed 21 albums
```

## Implementation Details

- Progress bar only shown when `verbose=True` (respects `--no-progress`)
- Uses `tqdm.write()` for error messages to avoid disrupting progress bar
- Added `flush=True` to print statements for proper output ordering
- Iterator wraps the album directory list for minimal code changes

## Testing

- Tested with 21 albums (203 files, 4.6GB)
- Verified progress bar updates smoothly
- Verified error messages display correctly without breaking bar
- All quality checks passed (black, ruff, mypy)

## Benefits

- User can see real-time progress during long scans
- ETA helps users plan their workflow
- Albums/second metric useful for performance monitoring