### PR TITLE
fix: prioritize albums without metadata for deletion

### DIFF
--- a/src/duperscooper/__main__.py
+++ b/src/duperscooper/__main__.py
@@ -246,12 +246,22 @@ def format_album_output_text(
         duplicates = [a for a in group if a != best_album]
 
         # Sort duplicates by quality ascending (worst first),
+        # then by metadata presence (albums without metadata first),
         # then match percentage descending
+        def _has_metadata(album: Any) -> bool:
+            """Check if album has MusicBrainz ID or album/artist tags"""
+            return bool(
+                album.musicbrainz_albumid or (album.album_name and album.artist_name)
+            )
+
         sorted_duplicates = sorted(
             duplicates,
             key=lambda a: (
-                a.avg_quality_score,
-                -_get_album_match_percentage(a, best_album, hasher),
+                a.avg_quality_score,  # Lower quality first
+                _has_metadata(a),  # No metadata first (False < True)
+                -_get_album_match_percentage(
+                    a, best_album, hasher
+                ),  # Higher match last
             ),
         )
 
@@ -324,11 +334,18 @@ def format_album_output_json(
         # Separate best from duplicates
         duplicates = [a for a in group if a != best_album]
 
-        # Sort duplicates by quality ascending, then match % descending
+        # Sort duplicates by quality ascending, metadata presence, match % descending
+        def _has_metadata(album: Any) -> bool:
+            """Check if album has MusicBrainz ID or album/artist tags"""
+            return bool(
+                album.musicbrainz_albumid or (album.album_name and album.artist_name)
+            )
+
         sorted_duplicates = sorted(
             duplicates,
             key=lambda a: (
                 a.avg_quality_score,
+                _has_metadata(a),
                 -_get_album_match_percentage(a, best_album, hasher),
             ),
         )
@@ -393,11 +410,18 @@ def format_album_output_csv(
         # Separate best from duplicates
         duplicates = [a for a in group if a != best_album]
 
-        # Sort duplicates by quality ascending, then match % descending
+        # Sort duplicates by quality ascending, metadata presence, match % descending
+        def _has_metadata(album: Any) -> bool:
+            """Check if album has MusicBrainz ID or album/artist tags"""
+            return bool(
+                album.musicbrainz_albumid or (album.album_name and album.artist_name)
+            )
+
         sorted_duplicates = sorted(
             duplicates,
             key=lambda a: (
                 a.avg_quality_score,
+                _has_metadata(a),
                 -_get_album_match_percentage(a, best_album, hasher),
             ),
         )


### PR DESCRIPTION
## Problem

When sorting duplicates for deletion priority, albums at the same quality level were sorted only by match percentage. This meant a 64kbps MP3 **with** MusicBrainz tags appeared before a 64kbps MP3 **without** tags.

The untagged version is clearly the more urgent deletion candidate since it has less metadata value.

## Solution

Updated sorting to consider metadata presence as a tiebreaker between albums of equal quality:

**New sorting order:**
1. Quality score (worst first)
2. Metadata presence (no metadata first)
3. Match percentage (lower match first)

Albums without MusicBrainz IDs **or** album/artist tags now appear before those with metadata at the same quality level.

## Example

**Before:**
```
[Best] FLAC with MB
  64kbps with MB      ← Has metadata
  64kbps no tags      ← No metadata (but listed second)
```

**After:**
```
[Best] FLAC with MB
  64kbps no tags      ← No metadata (listed first - priority delete)
  64kbps with MB      ← Has metadata
```

## Testing

Verified with test-albums/:
- Group 2 now correctly shows AlbumB-MP3-no-MB-064 before AlbumB-MP3-with-MB-064
- Applied to all output formats (text, JSON, CSV)
- All quality checks passed (black, ruff, mypy)

## Impact

Better deletion prioritization for users - albums with less metadata value are suggested for deletion first.